### PR TITLE
Add disjoint prep plus tail benchmark circuit

### DIFF
--- a/benchmark_circuits.py
+++ b/benchmark_circuits.py
@@ -198,6 +198,208 @@ def _apply_rotation_tail_layer(qc: QuantumCircuit, rng: np.random.Generator, ang
     for a,b in _pairing(order):
         qc.cz(a,b)
 
+
+def _apply_ry_via_rz_h(qc: QuantumCircuit, qubit: int, theta: float) -> None:
+    """Apply an ``RY(theta)`` rotation using only ``H`` and ``RZ`` gates."""
+    qc.rz(-math.pi / 2, qubit)
+    qc.h(qubit)
+    qc.rz(theta, qubit)
+    qc.h(qubit)
+    qc.rz(math.pi / 2, qubit)
+
+
+def _prepare_ghz_block(qc: QuantumCircuit, block: list[int]) -> None:
+    if not block:
+        return
+    first = block[0]
+    qc.h(first)
+    for target in block[1:]:
+        qc.cx(first, target)
+
+
+def _prepare_w_block(qc: QuantumCircuit, block: list[int]) -> None:
+    size = len(block)
+    if size == 0:
+        return
+    if size == 1:
+        qc.x(block[0])
+        return
+    for i in range(size - 1):
+        remaining = size - i
+        theta = 2.0 * math.acos(math.sqrt((remaining - 1) / remaining))
+        _apply_ry_via_rz_h(qc, block[i], theta)
+        qc.cx(block[i], block[i + 1])
+    qc.x(block[-1])
+
+
+def _clifford_tail_layer(qc: QuantumCircuit, block: list[int], rng: np.random.Generator) -> None:
+    if not block:
+        return
+    one_qubit = ("h", "s", "x", "z")
+    for qubit in block:
+        gate = rng.choice(one_qubit)
+        getattr(qc, gate)(qubit)
+    shuffled = block.copy()
+    rng.shuffle(shuffled)
+    for a, b in zip(shuffled[::2], shuffled[1::2]):
+        if rng.random() < 0.5:
+            qc.cx(a, b)
+        else:
+            qc.cx(b, a)
+
+
+def _diag_tail_layer(
+    qc: QuantumCircuit,
+    block: list[int],
+    rng: np.random.Generator,
+    *,
+    angle_scale: float,
+    sparsity: float,
+    bandwidth: int,
+) -> None:
+    size = len(block)
+    if size == 0:
+        return
+    num_rz = int(round(sparsity * size))
+    num_rz = max(0, min(size, num_rz))
+    if num_rz > 0:
+        targets = list(rng.choice(block, size=num_rz, replace=False))
+        for qubit in targets:
+            theta = float(rng.uniform(-angle_scale, angle_scale))
+            qc.rz(theta, qubit)
+    num_pairs = num_rz // 2
+    if num_pairs <= 0 or bandwidth <= 0:
+        return
+    edges: list[tuple[int, int]] = []
+    for idx, control in enumerate(block):
+        for offset in range(1, bandwidth + 1):
+            partner_index = idx + offset
+            if partner_index < size:
+                edges.append((control, block[partner_index]))
+    if not edges:
+        return
+    num_pairs = min(num_pairs, len(edges))
+    chosen = rng.choice(len(edges), size=num_pairs, replace=False)
+    for edge_index in np.atleast_1d(chosen):
+        a, b = edges[int(edge_index)]
+        qc.cz(a, b)
+
+
+def disjoint_preps_plus_tails(
+    *,
+    num_qubits: int,
+    num_blocks: int,
+    block_prep: str = "mixed",
+    tail_kind: str = "mixed",
+    tail_depth: int = 20,
+    angle_scale: float = 0.1,
+    sparsity: float = 0.05,
+    bandwidth: int = 2,
+    seed: int = 7,
+) -> "QuantumCircuit":
+    """Build a block-disjoint circuit with configurable preparations and tails.
+
+    Args:
+        num_qubits: Total number of qubits in the circuit.
+        num_blocks: Number of contiguous, non-overlapping blocks to partition the
+            qubits into. Each block has size either ``floor(n/k)`` or ``ceil(n/k)``
+            and contains only consecutive qubits.
+        block_prep: Preparation per block. ``"ghz"`` prepares every block as a GHZ
+            state using only intra-block CX gates, ``"w"`` prepares every block as a
+            W state, and ``"mixed"`` alternates between GHZ (even-indexed blocks)
+            and W (odd-indexed blocks).
+        tail_kind: Tail layer family applied after preparation. ``"clifford"``
+            applies random single-qubit Clifford gates and sparse CX gates within
+            each block, ``"diag"`` applies sparse RZ rotations and banded CZ gates
+            per block, ``"none"`` adds no tail, and ``"mixed"`` alternates between
+            Clifford and diagonal tails (even-indexed blocks receive Clifford).
+        tail_depth: Number of tail layers applied to each block (ignored when
+            ``tail_kind`` is ``"none"``).
+        angle_scale: Maximum rotation magnitude for diagonal tails; RZ angles are
+            sampled uniformly from ``[-angle_scale, angle_scale]``.
+        sparsity: Fraction of qubits per block that receive an RZ rotation in each
+            diagonal-tail layer. The number of CZ gates is approximately half the
+            number of rotated qubits.
+        bandwidth: Maximum separation (in indices within a block) for CZ gates in
+            diagonal tails.
+        seed: Seed for the pseudo-random number generator controlling gate
+            selection.
+
+    Returns:
+        A ``QuantumCircuit`` whose multi-qubit interactions are restricted to be
+        entirely within each contiguous block. No gate spans two different blocks.
+    """
+
+    if num_qubits <= 0:
+        raise ValueError("num_qubits must be positive")
+    if num_blocks <= 0:
+        raise ValueError("num_blocks must be positive")
+    if num_blocks > num_qubits:
+        raise ValueError("num_blocks cannot exceed num_qubits")
+
+    block_prep = block_prep.lower()
+    if block_prep not in {"ghz", "w", "mixed"}:
+        raise ValueError(f"Unsupported block_prep '{block_prep}'")
+
+    tail_kind = tail_kind.lower()
+    if tail_kind not in {"clifford", "diag", "none", "mixed"}:
+        raise ValueError(f"Unsupported tail_kind '{tail_kind}'")
+
+    rng = np.random.default_rng(seed)
+    qc = QuantumCircuit(num_qubits)
+
+    base = num_qubits // num_blocks
+    remainder = num_qubits % num_blocks
+    blocks: list[list[int]] = []
+    start = 0
+    for idx in range(num_blocks):
+        size = base + (1 if idx < remainder else 0)
+        block = list(range(start, start + size))
+        if not block:
+            raise ValueError("Encountered empty block; check num_qubits/num_blocks")
+        blocks.append(block)
+        start += size
+
+    prep_choices = []
+    for idx in range(num_blocks):
+        if block_prep == "mixed":
+            prep_choices.append("ghz" if idx % 2 == 0 else "w")
+        else:
+            prep_choices.append(block_prep)
+
+    tail_choices = []
+    for idx in range(num_blocks):
+        if tail_kind == "mixed":
+            tail_choices.append("clifford" if idx % 2 == 0 else "diag")
+        else:
+            tail_choices.append(tail_kind)
+
+    for idx, block in enumerate(blocks):
+        if prep_choices[idx] == "ghz":
+            _prepare_ghz_block(qc, block)
+        else:
+            _prepare_w_block(qc, block)
+
+        tail = tail_choices[idx]
+        if tail == "none" or tail_depth <= 0:
+            continue
+        for _ in range(tail_depth):
+            if tail == "clifford":
+                _clifford_tail_layer(qc, block, rng)
+            elif tail == "diag":
+                _diag_tail_layer(
+                    qc,
+                    block,
+                    rng,
+                    angle_scale=angle_scale,
+                    sparsity=sparsity,
+                    bandwidth=bandwidth,
+                )
+            else:
+                raise ValueError(f"Unexpected tail kind '{tail}' after normalization")
+
+    return qc
+
 # --- NEW: builder with a cutoff fraction ---
 def clifford_prefix_rot_tail(*, num_qubits: int, depth: int, cutoff: float,
                              angle_scale: float = 0.1, seed: int = 1) -> QuantumCircuit:
@@ -222,6 +424,7 @@ CIRCUIT_REGISTRY = {
     "stitched_diag_bandedqft_diag": stitched_disjoint_diag_bandedqft_diag,
     "clifford_plus_rot": clifford_plus_random_rotations,
     "clifford_prefix_rot_tail": clifford_prefix_rot_tail,
+    "disjoint_preps_plus_tails": disjoint_preps_plus_tails,
 }
 
 def build(kind: str, **kwargs) -> QuantumCircuit:


### PR DESCRIPTION
## Summary
- add a disjoint_preps_plus_tails circuit generator supporting GHZ/W block preparations and configurable tails
- ensure the new generator reuses only intra-block gates and is available through the registry

## Testing
- python - <<'PY'
from benchmark_circuits import disjoint_preps_plus_tails

qc = disjoint_preps_plus_tails(num_qubits=16, num_blocks=4, block_prep="mixed", tail_kind="mixed", tail_depth=2, seed=1)
print(qc.num_qubits)

num_blocks = 4
block_ranges = []
base = qc.num_qubits // num_blocks
remainder = qc.num_qubits % num_blocks
start = 0
for idx in range(num_blocks):
    size = base + (1 if idx < remainder else 0)
    block_ranges.append(range(start, start + size))
    start += size

for inst in qc.data:
    qargs = inst.qubits
    if len(qargs) <= 1:
        continue
    indices = [qc.find_bit(qubit).index for qubit in qargs]
    block_ids = {next(i for i, r in enumerate(block_ranges) if index in r) for index in indices}
    assert len(block_ids) == 1
print("ok")
PY

------
https://chatgpt.com/codex/tasks/task_e_68e135fc8f38832181fed9e99195e89d