### PR TITLE
Improve simulation backend progress reporting

### DIFF
--- a/quasar/backends/dd.py
+++ b/quasar/backends/dd.py
@@ -1,6 +1,6 @@
 
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Optional, Any, Callable
 import numpy as np
 
 def ddsim_available() -> bool:
@@ -11,12 +11,76 @@ def ddsim_available() -> bool:
         return False
 
 class DecisionDiagramBackend:
-    def run(self, circuit: Any) -> Optional[np.ndarray]:
+    def run(
+        self,
+        circuit: Any,
+        *,
+        initial_state: Optional[np.ndarray] = None,
+        progress_cb: Optional[Callable[[int], None]] = None,
+        want_statevector: bool = True,
+        batch_size: int = 500,
+    ) -> Optional[np.ndarray]:
+        """Run the DDSIM backend while emitting coarse-grained progress callbacks."""
+
+        def _emit(count: int) -> None:
+            if progress_cb is not None and count:
+                progress_cb(int(count))
+
         try:
             import mqt.ddsim as ddsim  # type: ignore
+            if batch_size <= 0:
+                batch_size = 500
+
+            total_ops = 0
+            try:
+                total_ops = len(getattr(circuit, "data", []))
+            except Exception:
+                total_ops = 0
+
+            # Try to use a step-wise simulator if available (newer DDSIM releases).
+            try:
+                sim_cls = getattr(ddsim, "CircuitSimulator", None)
+                if sim_cls is not None:
+                    step_sim = sim_cls(circuit)
+                    step_fn = getattr(step_sim, "simulate", None)
+                    get_sv = getattr(step_sim, "get_statevector", None)
+                    processed = 0
+                    if callable(step_fn):
+                        while True:
+                            if total_ops and processed >= total_ops:
+                                break
+                            step = batch_size
+                            if total_ops:
+                                step = min(batch_size, total_ops - processed)
+                                if step <= 0:
+                                    break
+                            step_fn(step)
+                            processed += step
+                            _emit(step)
+                        if want_statevector and callable(get_sv):
+                            sv_data = get_sv()
+                            if sv_data is not None:
+                                return np.asarray(sv_data, dtype=np.complex128)
+                        if not want_statevector:
+                            return None
+            except Exception:
+                # Fall back to provider-based execution.
+                pass
+
             sim = ddsim.DDSIMProvider().get_backend('qasm_simulator')
-            job = sim.run(circuit, shots=0)
+            run_opts: dict[str, Any] = {"shots": 0}
+            if initial_state is not None:
+                run_opts["initial_statevector"] = initial_state
+            try:
+                job = sim.run(circuit, **run_opts)
+            except TypeError:
+                # Older interfaces might not understand initial_statevector.
+                run_opts.pop("initial_statevector", None)
+                job = sim.run(circuit, **run_opts)
             res = job.result()
+            _emit(total_ops or 1)
+            if not want_statevector:
+                return None
             if hasattr(res, "get_statevector"):
                 sv = res.get_statevector(circuit)
                 return np.asarray(sv, dtype=np.complex128)

--- a/quasar/backends/sv.py
+++ b/quasar/backends/sv.py
@@ -1,6 +1,6 @@
 
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Optional, Any, Callable
 import numpy as np
 
 def estimate_sv_bytes(n_qubits: int) -> int:
@@ -17,25 +17,74 @@ class StatevectorBackend:
         except Exception:
             self._aer = None
 
-    def run(self, circuit: Any, initial_state: Optional[np.ndarray] = None) -> Optional[np.ndarray]:
+    def run(
+        self,
+        circuit: Any,
+        initial_state: Optional[np.ndarray] = None,
+        *,
+        progress_cb: Optional[Callable[[int], None]] = None,
+        want_statevector: bool = True,
+        batch_size: int = 1000,
+    ) -> Optional[np.ndarray]:
+        """Simulate *circuit* as a statevector while emitting periodic progress callbacks."""
+
+        def _emit_progress(count: int) -> None:
+            if progress_cb is not None and count:
+                progress_cb(int(count))
+
         try:
             from qiskit.quantum_info import Statevector
+
+            if batch_size <= 0:
+                batch_size = 1000
+
+            qubits = list(getattr(circuit, "qubits", []))
+            num_qubits = getattr(circuit, "num_qubits", len(qubits)) or 0
+            if not qubits and num_qubits:
+                qubits = [None] * num_qubits  # fallback so len works
+            qindex = {q: i for i, q in enumerate(qubits)}
+
             if initial_state is None:
-                sv = Statevector.from_instruction(circuit)
+                if num_qubits <= 0:
+                    return None if not want_statevector else np.array([1.0 + 0.0j], dtype=np.complex128)
+                state = Statevector.from_int(0, dims=(2,) * num_qubits)
             else:
-                sv = Statevector(initial_state)
-                sv = sv.evolve(circuit)
-            return np.asarray(sv.data, dtype=np.complex128)
+                state = Statevector(initial_state)
+
+            data = list(getattr(circuit, "data", []))
+            processed_in_batch = 0
+            for inst, qargs, _ in data:
+                name = getattr(inst, "name", "")
+                if name.lower() in {"barrier", "snapshot"}:
+                    continue
+                try:
+                    indices = [qindex[q] for q in qargs]
+                except Exception:
+                    indices = None
+                try:
+                    state = state.evolve(inst, qargs=indices)
+                except Exception:
+                    state = state.evolve(inst)
+                processed_in_batch += 1
+                if processed_in_batch >= batch_size:
+                    _emit_progress(processed_in_batch)
+                    processed_in_batch = 0
+            if processed_in_batch:
+                _emit_progress(processed_in_batch)
+
+            return np.asarray(state.data, dtype=np.complex128) if want_statevector else None
         except Exception:
             try:
                 if self._aer is not None and initial_state is None:
                     from qiskit_aer import Aer
                     from qiskit import transpile
+
                     backend = Aer.get_backend('aer_simulator_statevector')
                     tqc = transpile(circuit, backend)
                     result = backend.run(tqc).result()
                     sv = result.get_statevector(tqc)
-                    return np.asarray(sv, dtype=np.complex128)
+                    _emit_progress(len(getattr(circuit, "data", [])) or 1)
+                    return np.asarray(sv, dtype=np.complex128) if want_statevector else None
             except Exception:
                 pass
         return None


### PR DESCRIPTION
## Summary
- add chunked progress updates and want_statevector handling to the statevector backend
- extend the decision diagram backend to emit progress callbacks and honour initial state and want_statevector flags
- plumb progress callbacks through the simulation engine and treat non-statevector results as successful when appropriate

## Testing
- pytest tests/test_tableau_stim.py -q *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e24819002c83218382cc04e7c9884e