### PR TITLE
Fix hybrid planner subcircuit wiring

### DIFF
--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -96,8 +96,13 @@ def _count_ops(ops: List):
 def _build_subcircuit_like(parent, ops: List):
     from qiskit import QuantumCircuit
     sub = QuantumCircuit(parent.num_qubits)
+    qubit_map = {parent.qubits[i]: sub.qubits[i] for i in range(parent.num_qubits)}
     for inst, qargs, cargs in ops:
-        sub.append(inst, qargs, cargs)
+        local_qargs = [qubit_map[q] for q in qargs]
+        sub.append(inst, local_qargs, cargs)
+    parent_meta = getattr(parent, "metadata", None)
+    if parent_meta:
+        sub.metadata = dict(parent_meta)
     return sub
 
 def _consider_hybrid(node: PartitionNode, cfg: PlannerConfig):


### PR DESCRIPTION
## Summary
- remap hybrid prefix/tail subcircuits onto their local qubits and preserve metadata used by downstream components
- add a regression test that ensures hybrid partitions only contain their own qubit objects and keep the global-to-local mapping

## Testing
- pytest test_clifford_tail.py::test_hybrid_partition_qubits_are_local -q

------
https://chatgpt.com/codex/tasks/task_e_68e270882c7c83219a59bac72ae08f51