### PR TITLE
Add optional SSD visualization utilities and CLI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,6 +163,44 @@ All plotters now live under `plots/`:
 Each plotter accepts `--suite-dir` (directory with suite JSON files) and `--out`
 for the output image path.
 
+## SSD visualisation CLI
+
+`scripts/visualize_ssd.py` offers a lightweight way to render the spatial
+structure diagrams (SSDs) produced by the circuit analyser. The helper is
+particularly convenient when exploring the benchmark generators because it can
+instantiate any registered circuit family and immediately draw the associated
+dependency graph.
+
+The script depends on the optional `networkx` and `matplotlib` packages. Install
+them alongside the core requirements to enable plotting:
+
+```bash
+pip install networkx matplotlib
+```
+
+Inspect the available circuit families and their canonical names:
+
+```bash
+python scripts/visualize_ssd.py --list
+```
+
+Once you have a target, generate it (optionally passing builder arguments) and
+either show the plot interactively or export it to disk:
+
+```bash
+# Render a stitched hybrid circuit and pop up the plot window
+python scripts/visualize_ssd.py hybrid_stitched --param n=16 --param block_size=4
+
+# Save the SSD of a disjoint circuit without opening a window
+python scripts/visualize_ssd.py disjoint_blocks --param n=24 --param blocks=3 \
+    --param prep=ghz --save disjoint_ssd.png --no-show
+```
+
+Each `--param` flag accepts `key=value` pairs that are forwarded verbatim to the
+underlying `benchmarks.build` helper. String literals can be given with or
+without quotes, while more complex types (lists, tuples, numbers) are parsed via
+`ast.literal_eval`.
+
 ## Calibration and playground scripts
 
 `scripts/` bundles calibration and exploratory tooling:

--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -1,6 +1,7 @@
 """Core QuASAr simulation and planning package."""
 
 from .SSD import SSD, PartitionNode
+from .ssd_visualization import visualize_ssd
 from .analyzer import analyze, AnalysisResult
 from .planner import plan, PlannerConfig
 from .simulation_engine import execute_ssd, ExecutionConfig
@@ -9,6 +10,7 @@ from .cost_estimator import CostEstimator
 __all__ = [
     "SSD",
     "PartitionNode",
+    "visualize_ssd",
     "analyze",
     "AnalysisResult",
     "plan",

--- a/quasar/ssd_visualization.py
+++ b/quasar/ssd_visualization.py
@@ -1,0 +1,166 @@
+"""Utilities for visualising :class:`~quasar.SSD` instances.
+
+The visualisation is implemented with :mod:`networkx` and kept optional. If the
+dependencies required for drawing (``networkx`` and ``matplotlib``) are not
+available the helper will raise a :class:`RuntimeError` explaining what needs to
+be installed.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple
+
+from .SSD import SSD
+
+try:  # pragma: no cover - optional dependency
+    import networkx as nx
+except Exception:  # pragma: no cover - optional dependency
+    nx = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional dependency
+    plt = None  # type: ignore
+
+__all__ = ["visualize_ssd"]
+
+
+def _ensure_networkx_available() -> None:
+    if nx is None:  # pragma: no cover - exercised only when dependency missing
+        raise RuntimeError(
+            "networkx is required for SSD visualisation. Install it with 'pip "
+            "install networkx' to enable this feature."
+        )
+
+
+def _ensure_matplotlib_available() -> None:
+    if plt is None:  # pragma: no cover - exercised only when dependency missing
+        raise RuntimeError(
+            "matplotlib is required to render SSD visualisations. Install it "
+            "with 'pip install matplotlib' to enable this feature."
+        )
+
+
+def _format_label(title: str, pairs: Iterable[Tuple[str, object]]) -> str:
+    lines = [title]
+    for key, value in pairs:
+        if value is None:
+            continue
+        lines.append(f"{key}: {value}")
+    return "\n".join(lines)
+
+
+def _pick_layout(graph):
+    if graph.number_of_nodes() <= 2:
+        # Degenerate cases are easier to read with a circular layout
+        return nx.circular_layout(graph)  # type: ignore[union-attr]
+    return nx.spring_layout(graph, seed=7)  # type: ignore[union-attr]
+
+
+def visualize_ssd(
+    ssd: SSD,
+    *,
+    show: bool = True,
+    save_path: Optional[str] = None,
+    ax=None,
+):
+    """Visualise an :class:`~quasar.SSD` instance using :mod:`networkx`.
+
+    Parameters
+    ----------
+    ssd:
+        The SSD to visualise.
+    show:
+        If ``True`` (default) the generated figure is displayed using
+        ``matplotlib``.
+    save_path:
+        Optional path where the figure should be saved.
+    ax:
+        Optional existing matplotlib axes to draw on. When omitted a new figure
+        and axes are created.
+    """
+
+    _ensure_networkx_available()
+    if ax is None:
+        _ensure_matplotlib_available()
+        fig, ax = plt.subplots(figsize=(max(6, len(ssd.partitions) * 2.5), 6))
+    else:
+        fig = ax.figure
+
+    graph = nx.DiGraph()  # type: ignore[union-attr]
+
+    meta_pairs = sorted(ssd.meta.items())
+    graph.add_node(  # type: ignore[union-attr]
+        "__ssd_root__",
+        label=_format_label("SSD", meta_pairs),
+        kind="ssd",
+    )
+
+    for node in ssd.partitions:
+        metrics = node.metrics or {}
+        metric_pairs = sorted(metrics.items())
+        info: list[Tuple[str, object]] = [
+            ("Qubits", ", ".join(map(str, node.qubits)) or "-"),
+            ("Backend", node.backend),
+        ]
+        info.extend(metric_pairs)
+        label = _format_label(f"Partition {node.id}", info)
+        node_id = f"partition_{node.id}"
+        graph.add_node(  # type: ignore[union-attr]
+            node_id,
+            label=label,
+            kind="partition",
+        )
+        graph.add_edge("__ssd_root__", node_id)  # type: ignore[union-attr]
+
+        chain_id = node.meta.get("chain_id") if node.meta else None
+        successor = node.meta.get("next_in_chain") if node.meta else None
+        if chain_id is not None:
+            chain_node = f"chain_{chain_id}"
+            if chain_node not in graph:  # type: ignore[union-attr]
+                graph.add_node(  # type: ignore[union-attr]
+                    chain_node,
+                    label=_format_label(f"Chain {chain_id}", []),
+                    kind="chain",
+                )
+                graph.add_edge("__ssd_root__", chain_node)  # type: ignore[union-attr]
+            graph.add_edge(chain_node, node_id)  # type: ignore[union-attr]
+        if successor is not None:
+            succ_id = f"partition_{successor}"
+            if succ_id in graph:  # type: ignore[union-attr]
+                graph.add_edge(node_id, succ_id)  # type: ignore[union-attr]
+
+    layout = _pick_layout(graph)
+    labels = {n: data.get("label", str(n)) for n, data in graph.nodes(data=True)}
+    colors = []
+    for _, data in graph.nodes(data=True):
+        kind = data.get("kind")
+        if kind == "ssd":
+            colors.append("#4477AA")
+        elif kind == "chain":
+            colors.append("#AA3377")
+        else:
+            colors.append("#66C2A5")
+
+    nx.draw_networkx_nodes(  # type: ignore[union-attr]
+        graph,
+        layout,
+        node_color=colors,
+        ax=ax,
+        node_size=3000,
+        edgecolors="black",
+    )
+    nx.draw_networkx_edges(graph, layout, ax=ax, arrows=True, arrowstyle="-|>")  # type: ignore[union-attr]
+    nx.draw_networkx_labels(graph, layout, labels=labels, ax=ax, font_size=8)  # type: ignore[union-attr]
+
+    ax.set_axis_off()
+    ax.set_title("SSD visualisation")
+
+    if save_path:
+        _ensure_matplotlib_available()
+        fig.savefig(save_path, bbox_inches="tight")
+    if show:
+        _ensure_matplotlib_available()
+        plt.show()
+
+    return ax

--- a/scripts/visualize_ssd.py
+++ b/scripts/visualize_ssd.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from typing import Dict, Any
+
+from benchmarks import CIRCUIT_REGISTRY, build as build_circuit
+from quasar.analyzer import analyze
+from quasar.ssd_visualization import visualize_ssd
+
+
+def _parse_param(values: list[str]) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+    for item in values:
+        if "=" not in item:
+            raise SystemExit(f"Invalid --param '{item}'. Expected format key=value.")
+        key, raw_value = item.split("=", 1)
+        try:
+            value = ast.literal_eval(raw_value)
+        except (ValueError, SyntaxError):
+            value = raw_value
+        params[key] = value
+    return params
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Build a benchmark circuit and visualise the resulting SSD graph. "
+            "This requires networkx and matplotlib to be installed."
+        )
+    )
+    ap.add_argument(
+        "kind",
+        nargs="?",
+        choices=sorted(CIRCUIT_REGISTRY.keys()),
+        help="Circuit kind to generate.",
+    )
+    ap.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        help="Additional circuit builder parameters in key=value form.",
+    )
+    ap.add_argument(
+        "--save",
+        type=str,
+        default=None,
+        help="If provided, save the visualisation to this path.",
+    )
+    ap.add_argument(
+        "--no-show",
+        action="store_true",
+        help="Disable showing the plot (useful when --save is specified).",
+    )
+    ap.add_argument(
+        "--list",
+        action="store_true",
+        help="List available circuit kinds and exit.",
+    )
+
+    args = ap.parse_args(argv)
+
+    if args.list:
+        for name in sorted(CIRCUIT_REGISTRY.keys()):
+            print(name)
+        return 0
+
+    if not args.kind:
+        ap.error("circuit kind is required unless --list is provided")
+
+    params = _parse_param(args.param)
+    circuit = build_circuit(args.kind, **params)
+
+    analysis = analyze(circuit)
+    visualize_ssd(analysis.ssd, show=not args.no_show, save_path=args.save)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add an optional NetworkX-powered SSD visualisation helper that formats partitions and metadata for plotting
- expose the visualisation helper via the public quasar package API
- provide a script that builds benchmark circuits and invokes the SSD visualiser

## Testing
- python -m compileall quasar/ssd_visualization.py scripts/visualize_ssd.py

------
https://chatgpt.com/codex/tasks/task_e_68e3730670dc83218df8fa405b9f2e33