### PR TITLE
Add timeout option to make_figures_and_tables suite runner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,8 @@ Useful flags:
 - `--results-dir` to reuse an existing suite output directory (defaults to
   `suite_hybrid`).
 - `--force` to re-run the suite even when JSON results are already present.
+- `--timeout` to abort the suite runner if it exceeds the specified number of
+  seconds (useful in CI to avoid stalls).
 - Planner controls (`--max-ram-gb`, `--conv-factor`, `--twoq-factor`) and
   baseline calibration (`--sv-ampops-per-sec`) are forwarded to
   `suites/run_hybrid_suite.py`.
@@ -160,6 +162,8 @@ Key options:
   rotations so you capture the mixed Clifford + rotation-tail experiment.
 - `--tail-depth`, `--angle-scale`, `--sparsity`, and `--bandwidth` refine the
   diagonal tail shape when present.
+- `--timeout` mirrors the hybrid workflow and stops the suite if it runs longer
+  than the configured limit.
 - As with the hybrid workflow, planner and baseline tuning flags are passed
   through to `suites/run_disjoint_suite.py`.
 


### PR DESCRIPTION
## Summary
- add an optional --timeout flag to the hybrid and disjoint subcommands in make_figures_and_tables so suite executions can be aborted after a deadline
- document the new timeout capability in the figure/table workflow guide

## Testing
- python -m compileall scripts/make_figures_and_tables.py


------
https://chatgpt.com/codex/tasks/task_e_68e3915a637483219382b9811fd938d0