### PR TITLE
Align paper plotting palette across CLI tools

### DIFF
--- a/plots/bar_clifford_tail.py
+++ b/plots/bar_clifford_tail.py
@@ -9,12 +9,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import matplotlib.pyplot as plt
 import numpy as np
 
-COLORS = {
-    "tableau": "#A5D6A7",  # pastel green
-    "sv": "#90CAF9",       # pastel blue
-    "dd": "#FFCCBC",       # pastel orange
-    "conversion": "#CFD8DC"  # pastel grey
-}
+from .palette import EDGE_COLOR, FALLBACK_COLOR, PASTEL_COLORS
+
+COLORS = PASTEL_COLORS
 
 KINDS = {"clifford_plus_rot", "clifford_prefix_rot_tail"}
 
@@ -263,13 +260,28 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
 
         bottom = 0.0
         if tab > 0:
-            ax.bar(0, tab, width, color=COLORS["tableau"], edgecolor="black")
+            ax.bar(0, tab, width, color=COLORS["tableau"], edgecolor=EDGE_COLOR)
             bottom += tab
         if conv > 0:
-            ax.bar(0, conv, width, bottom=bottom, color=COLORS["conversion"], edgecolor="black", hatch="//")
+            ax.bar(
+                0,
+                conv,
+                width,
+                bottom=bottom,
+                color=COLORS["conversion"],
+                edgecolor=EDGE_COLOR,
+                hatch="//",
+            )
             bottom += conv
         if tail > 0:
-            ax.bar(0, tail, width, bottom=bottom, color=COLORS.get(tail_method, COLORS["sv"]), edgecolor="black")
+            ax.bar(
+                0,
+                tail,
+                width,
+                bottom=bottom,
+                color=COLORS.get(tail_method, FALLBACK_COLOR),
+                edgecolor=EDGE_COLOR,
+            )
 
         total_quasar = tab + conv + tail
         if total_quasar > 0 and np.isfinite(base_time) and base_time > 0:
@@ -286,7 +298,14 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
             )
 
         if np.isfinite(base_time) and base_time > 0:
-            ax.bar(1, base_time, width, color=COLORS.get(base_method, COLORS["sv"]), edgecolor="black", alpha=0.9)
+            ax.bar(
+                1,
+                base_time,
+                width,
+                color=COLORS.get(base_method, FALLBACK_COLOR),
+                edgecolor=EDGE_COLOR,
+                alpha=0.9,
+            )
 
         ax.set_xticks([0, 1])
         ax.set_xticklabels(["QuASAr", "Baseline"])
@@ -312,17 +331,41 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
 
     legend_handles = []
     if tableau_used:
-        legend_handles.append(mpatches.Patch(color=COLORS["tableau"], edgecolor="black", label="QuASAr: tableau"))
+        legend_handles.append(
+            mpatches.Patch(
+                color=COLORS["tableau"], edgecolor=EDGE_COLOR, label="QuASAr: tableau"
+            )
+        )
     if conversion_used:
-        legend_handles.append(mpatches.Patch(color=COLORS["conversion"], edgecolor="black", hatch="//", label="QuASAr: conversion"))
+        legend_handles.append(
+            mpatches.Patch(
+                color=COLORS["conversion"],
+                edgecolor=EDGE_COLOR,
+                hatch="//",
+                label="QuASAr: conversion",
+            )
+        )
     for method in sorted(tail_methods_used):
         method_label = str(method).upper()
         label = f"QuASAr tail: {method_label}"
-        legend_handles.append(mpatches.Patch(color=COLORS.get(method, COLORS["sv"]), edgecolor="black", label=label))
+        legend_handles.append(
+            mpatches.Patch(
+                color=COLORS.get(method, FALLBACK_COLOR),
+                edgecolor=EDGE_COLOR,
+                label=label,
+            )
+        )
     for method in sorted(base_methods_used):
         method_label = str(method).upper()
         label = f"Baseline: {method_label}"
-        legend_handles.append(mpatches.Patch(color=COLORS.get(method, COLORS["sv"]), edgecolor="black", alpha=0.9, label=label))
+        legend_handles.append(
+            mpatches.Patch(
+                color=COLORS.get(method, FALLBACK_COLOR),
+                edgecolor=EDGE_COLOR,
+                alpha=0.9,
+                label=label,
+            )
+        )
 
     if legend_handles:
         fig.legend(handles=legend_handles, loc="upper right")

--- a/plots/bar_disjoint.py
+++ b/plots/bar_disjoint.py
@@ -9,15 +9,17 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import matplotlib.pyplot as plt
 import numpy as np
 
-QUASAR_COLOR = "#7E57C2"
+from .palette import EDGE_COLOR, FALLBACK_COLOR, PASTEL_COLORS
+
+QUASAR_COLOR = PASTEL_COLORS["tableau"]
 BASELINE_COLORS = {
-    "sv": "#1E88E5",
-    "statevector": "#1E88E5",
-    "state_vector": "#1E88E5",
-    "dd": "#F4511E",
-    "decisiondiagram": "#F4511E",
-    "decision_diagram": "#F4511E",
-    "tableau": "#4CAF50",
+    "sv": PASTEL_COLORS["sv"],
+    "statevector": PASTEL_COLORS["sv"],
+    "state_vector": PASTEL_COLORS["sv"],
+    "dd": PASTEL_COLORS["dd"],
+    "decisiondiagram": PASTEL_COLORS["dd"],
+    "decision_diagram": PASTEL_COLORS["dd"],
+    "tableau": PASTEL_COLORS["tableau"],
 }
 
 CASE_KIND = "disjoint_preps_plus_tails"
@@ -146,10 +148,24 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
     width = 0.38
 
     plt.figure(figsize=(max(8, len(labels) * 1.4), 5.5))
-    plt.bar(x - width / 2, quasar_times, width, label="QuASAr (parallel disjoint)", color=QUASAR_COLOR)
+    plt.bar(
+        x - width / 2,
+        quasar_times,
+        width,
+        label="QuASAr (parallel disjoint)",
+        color=QUASAR_COLOR,
+        edgecolor=EDGE_COLOR,
+    )
 
-    baseline_colors = [BASELINE_COLORS.get(m, "#9E9E9E") for m in baseline_methods]
-    plt.bar(x + width / 2, baseline_times, width, color=baseline_colors)
+    baseline_colors = [BASELINE_COLORS.get(m, FALLBACK_COLOR) for m in baseline_methods]
+    plt.bar(
+        x + width / 2,
+        baseline_times,
+        width,
+        color=baseline_colors,
+        edgecolor=EDGE_COLOR,
+        alpha=0.9,
+    )
 
     plt.xticks(x, labels, rotation=25, ha="right")
     plt.ylabel("Time (s)")
@@ -158,10 +174,26 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
     import matplotlib.patches as mpatches
 
     legend_handles = [
-        mpatches.Patch(color=QUASAR_COLOR, label="QuASAr (parallel disjoint)"),
-        mpatches.Patch(color=BASELINE_COLORS["sv"], label="Baseline: SV"),
-        mpatches.Patch(color=BASELINE_COLORS["dd"], label="Baseline: DD"),
-        mpatches.Patch(color=BASELINE_COLORS["tableau"], label="Baseline: Tableau"),
+        mpatches.Patch(
+            color=QUASAR_COLOR,
+            edgecolor=EDGE_COLOR,
+            label="QuASAr (parallel disjoint)",
+        ),
+        mpatches.Patch(
+            color=BASELINE_COLORS["sv"],
+            edgecolor=EDGE_COLOR,
+            label="Baseline: SV",
+        ),
+        mpatches.Patch(
+            color=BASELINE_COLORS["dd"],
+            edgecolor=EDGE_COLOR,
+            label="Baseline: DD",
+        ),
+        mpatches.Patch(
+            color=BASELINE_COLORS["tableau"],
+            edgecolor=EDGE_COLOR,
+            label="Baseline: Tableau",
+        ),
     ]
     plt.legend(handles=legend_handles, loc="best")
     plt.tight_layout()

--- a/plots/bar_hybrid.py
+++ b/plots/bar_hybrid.py
@@ -9,12 +9,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import matplotlib.pyplot as plt
 import numpy as np
 
-COLORS = {
-    "tableau": "#4CAF50",
-    "sv": "#1E88E5",
-    "dd": "#F4511E",
-    "conversion": "#9E9E9E"
-}
+from .palette import EDGE_COLOR, FALLBACK_COLOR, PASTEL_COLORS
+
+COLORS = PASTEL_COLORS
 
 KINDS = {"clifford_plus_rot", "clifford_prefix_rot_tail", "dd_friendly_prefix_diag_tail"}
 
@@ -156,25 +153,62 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
     x = np.arange(N)
     width = 0.42
 
-    plt.figure(figsize=(max(8, N*1.3), 5))
-    plt.bar(x - width/2, t_tab, width, label="QuASAr: tableau", color=COLORS["tableau"])
-    plt.bar(x - width/2, t_conv, width, bottom=t_tab, label="QuASAr: conversion", color=COLORS["conversion"], hatch='//', edgecolor='black')
+    plt.figure(figsize=(max(8, N * 1.3), 5))
+    plt.bar(
+        x - width / 2,
+        t_tab,
+        width,
+        label="QuASAr: tableau",
+        color=COLORS["tableau"],
+        edgecolor=EDGE_COLOR,
+    )
+    plt.bar(
+        x - width / 2,
+        t_conv,
+        width,
+        bottom=t_tab,
+        label="QuASAr: conversion",
+        color=COLORS["conversion"],
+        hatch="//",
+        edgecolor=EDGE_COLOR,
+    )
     bottoms = np.array(t_tab) + np.array(t_conv)
-    tail_colors = [COLORS.get(m, COLORS["sv"]) for m in tail_methods]
-    plt.bar(x - width/2, t_tail, width, bottom=bottoms, label="QuASAr: tail", color=tail_colors)
+    tail_colors = [COLORS.get(m, FALLBACK_COLOR) for m in tail_methods]
+    plt.bar(
+        x - width / 2,
+        t_tail,
+        width,
+        bottom=bottoms,
+        label="QuASAr: tail",
+        color=tail_colors,
+        edgecolor=EDGE_COLOR,
+    )
 
-    base_colors = [COLORS.get(m, COLORS["sv"]) for m in base_methods]
-    plt.bar(x + width/2, base_times, width, label="Baseline (whole circuit)", color=base_colors, alpha=0.9)
+    base_colors = [COLORS.get(m, FALLBACK_COLOR) for m in base_methods]
+    plt.bar(
+        x + width / 2,
+        base_times,
+        width,
+        label="Baseline (whole circuit)",
+        color=base_colors,
+        edgecolor=EDGE_COLOR,
+        alpha=0.9,
+    )
 
     plt.xticks(x, labels, rotation=25, ha='right')
     plt.ylabel("Time (s)")
     plt.title(title or "QuASAr (stacked) vs whole-circuit baseline")
     import matplotlib.patches as mpatches
     legend_handles = [
-        mpatches.Patch(color=COLORS["tableau"], label="QuASAr: tableau"),
-        mpatches.Patch(color=COLORS["conversion"], label="QuASAr: conversion", hatch='//', edgecolor='black'),
-        mpatches.Patch(color=COLORS["sv"], label="Tail/Baseline: SV"),
-        mpatches.Patch(color=COLORS["dd"], label="Tail/Baseline: DD"),
+        mpatches.Patch(color=COLORS["tableau"], edgecolor=EDGE_COLOR, label="QuASAr: tableau"),
+        mpatches.Patch(
+            color=COLORS["conversion"],
+            edgecolor=EDGE_COLOR,
+            hatch="//",
+            label="QuASAr: conversion",
+        ),
+        mpatches.Patch(color=COLORS["sv"], edgecolor=EDGE_COLOR, label="Tail/Baseline: SV"),
+        mpatches.Patch(color=COLORS["dd"], edgecolor=EDGE_COLOR, label="Tail/Baseline: DD"),
     ]
     plt.legend(handles=legend_handles, loc="best")
     plt.tight_layout()

--- a/plots/palette.py
+++ b/plots/palette.py
@@ -1,0 +1,53 @@
+"""Shared colour palette and Matplotlib styling for QuASAr plots."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+# Pastel palette matching the paper figures.
+PASTEL_COLORS: Dict[str, str] = {
+    "tableau": "#A5D6A7",  # pastel green
+    "sv": "#90CAF9",  # pastel blue
+    "dd": "#FFCCBC",  # pastel orange
+    "conversion": "#CFD8DC",  # pastel grey
+}
+
+# Fallback colour when a backend/method-specific colour is not available.
+FALLBACK_COLOR = "#B0BEC5"
+
+# Default outline colour for bar plots.
+EDGE_COLOR = "#37474F"
+
+
+def apply_paper_style() -> None:
+    """Apply a Matplotlib style roughly matching the paper figures."""
+
+    try:  # Import lazily so the module can be used without Matplotlib installed.
+        import matplotlib as mpl
+        from cycler import cycler
+    except Exception:
+        return
+
+    colour_cycle = [
+        PASTEL_COLORS["tableau"],
+        PASTEL_COLORS["conversion"],
+        PASTEL_COLORS["sv"],
+        PASTEL_COLORS["dd"],
+    ]
+
+    mpl.rcParams.update(
+        {
+            "figure.facecolor": "white",
+            "axes.facecolor": "white",
+            "axes.edgecolor": EDGE_COLOR,
+            "axes.labelcolor": "#1F2933",
+            "axes.titlesize": 12,
+            "axes.titleweight": "semibold",
+            "axes.prop_cycle": cycler(color=colour_cycle),
+            "xtick.color": "#1F2933",
+            "ytick.color": "#1F2933",
+            "grid.color": "#E0E0E0",
+        }
+    )
+

--- a/scripts/bench_from_thresholds.py
+++ b/scripts/bench_from_thresholds.py
@@ -14,6 +14,11 @@ from quasar.baselines import run_baselines
 from quasar.planner import PlannerConfig, plan
 from quasar.simulation_engine import ExecutionConfig, execute_ssd
 
+from plots.palette import apply_paper_style
+
+
+apply_paper_style()
+
 def load_thresholds(path: str) -> Dict[str, Any]:
     with open(path, "r") as f:
         data = json.load(f)

--- a/scripts/make_figures_and_tables.py
+++ b/scripts/make_figures_and_tables.py
@@ -16,8 +16,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from plots.palette import apply_paper_style
+
 ROOT = Path(__file__).resolve().parents[1]
 SUITES_DIR = ROOT / "suites"
+
+
+apply_paper_style()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a shared pastel palette helper for plots along with a Matplotlib paper style
- update the hybrid, disjoint, and threshold bar charts to reuse the shared colors and outlines
- apply the paper plotting style in the figure/table and threshold helper scripts so the outputs match

## Testing
- pytest tests/test_bench_from_thresholds.py


------
https://chatgpt.com/codex/tasks/task_e_68e3e7eccc988321afe799c053014bb3