### PR TITLE
Refine disjoint benchmark defaults and plot styling

### DIFF
--- a/benchmarks/disjoint.py
+++ b/benchmarks/disjoint.py
@@ -75,8 +75,11 @@ def _diag_tail_layer(
     size = len(block)
     if size == 0:
         return
-    num_rz = int(round(sparsity * size))
-    num_rz = max(0, min(size, num_rz))
+    if sparsity <= 0:
+        num_rz = 0
+    else:
+        num_rz = math.ceil(sparsity * size)
+        num_rz = max(1, min(size, num_rz))
     if num_rz > 0:
         targets = list(rng.choice(block, size=num_rz, replace=False))
         for qubit in targets:


### PR DESCRIPTION
## Summary
- update the disjoint bar chart to render per-case two-bar panels with dynamic legends and speedup annotations
- ensure diagonal tails always include at least one non-Clifford rotation when sparsity is positive so the default circuits aren’t stabilizer-only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ec37f13483218bfc3c7ea5377746