### PR TITLE
Handle disjoint baseline OOMs and plot memory usage

### DIFF
--- a/plots/bar_disjoint.py
+++ b/plots/bar_disjoint.py
@@ -97,35 +97,157 @@ def _is_whole_baseline(entry: Dict[str, Any]) -> bool:
     return False
 
 
-def _best_whole_baseline(baselines: Dict[str, Any]) -> Optional[Tuple[str, float]]:
+def _flatten_baseline_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(entry, dict):
+        return {}
+    flat = dict(entry)
+    res = flat.pop("result", None)
+    if isinstance(res, dict):
+        for key, val in res.items():
+            flat.setdefault(key, val)
+    if "method" not in flat and "which" in flat:
+        flat["method"] = flat.get("which")
+    if "scope" not in flat and "mode" in flat:
+        flat["scope"] = flat.get("mode")
+    if "wall_s_measured" not in flat and "elapsed_s" in flat:
+        try:
+            flat["wall_s_measured"] = float(flat.get("elapsed_s"))
+        except Exception:
+            pass
+    return flat
+
+
+def _pick_elapsed(payload: Dict[str, Any]) -> Optional[float]:
+    for key in ("wall_s_measured", "wall_s_estimated", "elapsed_s", "time_est_sec"):
+        if key in payload and payload[key] is not None:
+            try:
+                return float(payload[key])
+            except Exception:
+                continue
+    return None
+
+
+def _best_whole_baseline(
+    baselines: Dict[str, Any]
+) -> Optional[Tuple[str, float, Dict[str, Any]]]:
     entries = baselines.get("entries") if isinstance(baselines, dict) else None
     if not isinstance(entries, list):
         entries = []
-    best: Optional[Tuple[str, float]] = None
+    entries = [_flatten_baseline_entry(e) for e in entries]
+    best: Optional[Tuple[str, float, Dict[str, Any]]] = None
     for entry in entries:
         if not _is_whole_baseline(entry):
             continue
-        elapsed = entry.get("wall_s_measured")
+        elapsed = _pick_elapsed(entry)
         if elapsed is None:
-            elapsed = entry.get("wall_s_estimated")
-        elapsed_f = _safe_float(elapsed)
-        if elapsed_f is None:
             continue
-        method = (entry.get("method") or entry.get("name") or "sv").lower()
-        if best is None or elapsed_f < best[1]:
-            best = (method, elapsed_f)
+        method = (
+            entry.get("method")
+            or entry.get("which")
+            or entry.get("backend")
+            or entry.get("name")
+            or "sv"
+        ).lower()
+        if best is None or elapsed < best[1]:
+            best = (method, elapsed, entry)
+    if best is not None:
+        return best
+    for entry in entries:
+        if entry.get("ok") is False:
+            continue
+        elapsed = _pick_elapsed(entry)
+        if elapsed is None:
+            continue
+        method = (
+            entry.get("method")
+            or entry.get("which")
+            or entry.get("backend")
+            or entry.get("name")
+            or "sv"
+        ).lower()
+        if best is None or elapsed < best[1]:
+            best = (method, elapsed, entry)
     return best
 
 
-def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = None) -> None:
-    cases = _load_cases(suite_dir)
-    if not cases:
-        raise SystemExit("No matching cases found in suite_dir")
+def _bytes_to_gib(value: Optional[float]) -> float:
+    if value is None:
+        return float("nan")
+    return float(value) / (1024.0 ** 3)
 
+
+def _extract_quasar_memory_bytes(data: Dict[str, Any]) -> Optional[float]:
+    quasar = (data.get("quasar") or {})
+    execution = quasar.get("execution") or data.get("execution") or {}
+    results = execution.get("results")
+    if isinstance(results, list):
+        best: Optional[float] = None
+        for res in results:
+            if not isinstance(res, dict):
+                continue
+            mem = _safe_float(res.get("mem_bytes"))
+            if mem is None:
+                continue
+            if best is None or mem > best:
+                best = mem
+        if best is not None:
+            return best
+    planner = (quasar.get("analysis") or {}).get("ssd") if isinstance(quasar, dict) else None
+    if isinstance(planner, dict):
+        parts = planner.get("partitions")
+        if isinstance(parts, list):
+            best: Optional[float] = None
+            for part in parts:
+                mem = _safe_float((part or {}).get("mem_bytes"))
+                if mem is None:
+                    continue
+                if best is None or mem > best:
+                    best = mem
+            if best is not None:
+                return best
+    return None
+
+
+def _estimate_sv_bytes(num_qubits: int) -> int:
+    if num_qubits <= 0:
+        return 0
+    return 16 * (1 << int(num_qubits))
+
+
+def _extract_baseline_memory_bytes(
+    entry: Optional[Dict[str, Any]],
+    fallback_qubits: int,
+) -> Optional[float]:
+    if not isinstance(entry, dict):
+        return None
+    mem = entry.get("mem_bytes")
+    if mem is None:
+        mem = entry.get("mem_bytes_estimated")
+    if mem is None:
+        estimate = entry.get("estimate")
+        if isinstance(estimate, dict):
+            mem = estimate.get("mem_bytes")
+    if mem is None:
+        method = (
+            entry.get("method")
+            or entry.get("which")
+            or entry.get("backend")
+            or entry.get("name")
+            or "sv"
+        ).lower()
+        if method in {"sv", "statevector", "state_vector"}:
+            mem = _estimate_sv_bytes(fallback_qubits)
+    return _safe_float(mem)
+
+
+def _collect_case_metrics(cases: List[Dict[str, Any]]):
     labels: List[str] = []
     quasar_times: List[float] = []
     baseline_times: List[float] = []
     baseline_methods: List[str] = []
+    baseline_entries: List[Optional[Dict[str, Any]]] = []
+    quasar_mems: List[float] = []
+    baseline_mems: List[float] = []
 
     for data in cases:
         params = (data.get("case") or {}).get("params", {})
@@ -140,9 +262,40 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
         if best is None:
             baseline_methods.append("sv")
             baseline_times.append(float("nan"))
+            baseline_entries.append(None)
         else:
-            baseline_methods.append(best[0])
-            baseline_times.append(best[1])
+            method, elapsed, entry = best
+            baseline_methods.append(method)
+            baseline_times.append(elapsed)
+            baseline_entries.append(entry)
+
+        qm = _extract_quasar_memory_bytes(data)
+        quasar_mems.append(qm if qm is not None else float("nan"))
+
+        bm = _extract_baseline_memory_bytes(baseline_entries[-1], n)
+        baseline_mems.append(bm if bm is not None else float("nan"))
+
+    return {
+        "labels": labels,
+        "quasar_times": quasar_times,
+        "baseline_times": baseline_times,
+        "baseline_methods": baseline_methods,
+        "baseline_entries": baseline_entries,
+        "quasar_mems": quasar_mems,
+        "baseline_mems": baseline_mems,
+    }
+
+
+def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = None) -> None:
+    cases = _load_cases(suite_dir)
+    if not cases:
+        raise SystemExit("No matching cases found in suite_dir")
+
+    metrics = _collect_case_metrics(cases)
+    labels = metrics["labels"]
+    quasar_times = metrics["quasar_times"]
+    baseline_times = metrics["baseline_times"]
+    baseline_methods = metrics["baseline_methods"]
 
     count = len(labels)
     if count == 0:
@@ -206,6 +359,103 @@ def make_plot(suite_dir: str, out: Optional[str] = None, title: Optional[str] = 
         method
         for method, t in zip(baseline_methods, baseline_times)
         if np.isfinite(t) and t > 0
+    }
+
+    legend_handles = [
+        mpatches.Patch(
+            color=QUASAR_COLOR,
+            edgecolor=EDGE_COLOR,
+            label="QuASAr (parallel disjoint)",
+        )
+    ]
+
+    for method in sorted(baseline_used):
+        label_method = method.replace("_", " ").upper()
+        legend_handles.append(
+            mpatches.Patch(
+                color=BASELINE_COLORS.get(method, FALLBACK_COLOR),
+                edgecolor=EDGE_COLOR,
+                alpha=0.9,
+                label=f"Baseline: {label_method}",
+            )
+        )
+
+    if legend_handles:
+        fig.legend(handles=legend_handles, loc="upper right")
+
+    fig.tight_layout(rect=[0, 0, 1, 0.94])
+
+    if out:
+        fig.savefig(out, dpi=200)
+        print(f"Wrote {out}")
+    else:
+        plt.show()
+
+
+def make_memory_plot(
+    suite_dir: str,
+    out: Optional[str] = None,
+    title: Optional[str] = None,
+) -> None:
+    cases = _load_cases(suite_dir)
+    if not cases:
+        raise SystemExit("No matching cases found in suite_dir")
+
+    metrics = _collect_case_metrics(cases)
+    labels = metrics["labels"]
+    quasar_mems = metrics["quasar_mems"]
+    baseline_mems = metrics["baseline_mems"]
+    baseline_methods = metrics["baseline_methods"]
+
+    count = len(labels)
+    if count == 0:
+        raise SystemExit("No cases available for plotting")
+
+    width = 0.6
+    fig, axes = plt.subplots(1, count, figsize=(max(6, count * 3.6), 5.5), sharey=True)
+    if count == 1:
+        axes = [axes]
+
+    for idx, ax in enumerate(axes):
+        quasar_mem = quasar_mems[idx]
+        baseline_mem = baseline_mems[idx]
+        baseline_method = baseline_methods[idx]
+
+        if np.isfinite(quasar_mem) and quasar_mem > 0:
+            ax.bar(
+                0,
+                _bytes_to_gib(quasar_mem),
+                width,
+                color=QUASAR_COLOR,
+                edgecolor=EDGE_COLOR,
+            )
+
+        if np.isfinite(baseline_mem) and baseline_mem > 0:
+            ax.bar(
+                1,
+                _bytes_to_gib(baseline_mem),
+                width,
+                color=BASELINE_COLORS.get(baseline_method, FALLBACK_COLOR),
+                edgecolor=EDGE_COLOR,
+                alpha=0.9,
+            )
+
+        ax.set_xticks([0, 1])
+        ax.set_xticklabels(["QuASAr", "Baseline"])
+        ax.set_xlim(-0.75, 1.75)
+        ax.set_title(labels[idx])
+        ax.grid(axis="y", alpha=0.3)
+        if idx == 0:
+            ax.set_ylabel("Memory (GiB)")
+
+    fig.suptitle(title or "QuASAr (parallel disjoint) memory vs baseline")
+
+    import matplotlib.patches as mpatches
+
+    baseline_used = {
+        method
+        for method, m in zip(baseline_methods, baseline_mems)
+        if np.isfinite(m) and m > 0
     }
 
     legend_handles = [

--- a/scripts/make_figures_and_tables.py
+++ b/scripts/make_figures_and_tables.py
@@ -267,7 +267,10 @@ def cmd_hybrid(args: argparse.Namespace) -> None:
 
 
 def cmd_disjoint(args: argparse.Namespace) -> None:
-    from plots.bar_disjoint import make_plot as make_disjoint_bars
+    from plots.bar_disjoint import (
+        make_memory_plot as make_disjoint_memory_bars,
+        make_plot as make_disjoint_bars,
+    )
 
     suite_dir = Path(args.results_dir or "suite_disjoint").resolve()
     out_path = Path(args.out).resolve()
@@ -318,6 +321,14 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
 
     print(f"[make_figures] Building disjoint bar chart -> {out_path}")
     make_disjoint_bars(str(suite_dir), out=str(out_path), title=args.title)
+
+    if out_path.suffix:
+        memory_out = out_path.with_name(f"{out_path.stem}_memory{out_path.suffix}")
+    else:
+        memory_out = out_path.with_name(f"{out_path.name}_memory")
+
+    print(f"[make_figures] Building disjoint memory chart -> {memory_out}")
+    make_disjoint_memory_bars(str(suite_dir), out=str(memory_out), title=args.title)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add memory-aware error handling to baseline execution so MemoryError produces estimated time and memory
- update disjoint plotting utilities to reuse flattened baseline entries, expose memory metrics, and emit a memory chart alongside the timing plot
- ensure the CLI writes both plots for disjoint suites and cover the new MemoryError path with a unit test

## Testing
- pytest tests/test_baselines_runner.py


------
https://chatgpt.com/codex/tasks/task_e_68e3ef8b3f90832199b8d55245d3cade