### PR TITLE
Make ablation runtime plots relative to baseline

### DIFF
--- a/scripts/run_ablation_study.py
+++ b/scripts/run_ablation_study.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Run an ablation study over QuASAr's partitioning strategies.
+
+This helper builds a family of disjoint hybrid circuits and benchmarks three
+QuASAr variants:
+
+* **full** – standard QuASAr with disjoint partitioning and hybrid prefix/tail
+  decomposition enabled.
+* **no_disjoint** – QuASAr with disjoint partitioning disabled (the entire
+  circuit is executed as a single partition) while hybrid decomposition remains
+  available.
+* **no_hybrid** – QuASAr with the hybrid prefix/tail optimisation disabled
+  while keeping disjoint partitioning enabled.
+
+For each problem size the script writes a JSON summary and produces bar charts
+comparing the runtime of the three variants (in all cases normalised to the
+full QuASAr baseline).
+
+Run from the repository root, e.g.::
+
+    python -m scripts.run_ablation_study --n 16 24 32 --num-blocks 4
+
+The resulting artefacts are stored inside ``ablation_runs`` by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from benchmarks.disjoint import disjoint_preps_plus_tails
+from plots.palette import EDGE_COLOR, PASTEL_COLORS, apply_paper_style
+from quasar.SSD import SSD, PartitionNode
+from quasar.analyzer import analyze
+from quasar.baselines import run_baselines
+from quasar.planner import PlannerConfig, plan
+from quasar.simulation_engine import ExecutionConfig, execute_ssd
+
+
+apply_paper_style()
+
+
+# --------------------------------------------------------------------------------------
+# Data containers and utilities
+
+
+@dataclass
+class VariantResult:
+    name: str
+    ok: bool
+    wall_s: Optional[float]
+    planner_config: Dict[str, Any]
+    plan: Optional[Dict[str, Any]] = None
+    execution: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+    def to_json(self) -> Dict[str, Any]:
+        payload = {
+            "name": self.name,
+            "ok": self.ok,
+            "wall_elapsed_s": self.wall_s,
+            "planner_config": self.planner_config,
+        }
+        if self.plan is not None:
+            payload["plan"] = self.plan
+        if self.execution is not None:
+            payload["execution"] = self.execution
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+
+def _ensure_seed(seed: Optional[int], *, index: int) -> int:
+    if seed is None:
+        return 7 + 17 * index
+    return int(seed) + index
+
+
+def _collapse_to_single_partition(
+    circ,
+    metrics: MutableMapping[str, Any],
+    *,
+    total_qubits: int,
+) -> SSD:
+    """Return an SSD with a single partition covering the entire circuit."""
+
+    merged = SSD(meta={"total_qubits": int(total_qubits), "components": 1})
+    node = PartitionNode(
+        id=0,
+        qubits=list(range(int(total_qubits))),
+        circuit=circ,
+        metrics=dict(metrics),
+        meta={"ablation": "no_disjoint"},
+    )
+    merged.add(node)
+    return merged
+
+
+def _extract_wall_elapsed(exec_payload: Any) -> Optional[float]:
+    if not isinstance(exec_payload, MutableMapping):
+        return None
+    meta = exec_payload.get("meta")
+    if isinstance(meta, MutableMapping):
+        wall = meta.get("wall_elapsed_s")
+        if isinstance(wall, (int, float)):
+            return float(wall)
+    results = exec_payload.get("results")
+    if isinstance(results, Iterable):
+        total = 0.0
+        found = False
+        for entry in results:
+            if not isinstance(entry, MutableMapping):
+                continue
+            elapsed = entry.get("elapsed_s")
+            if isinstance(elapsed, (int, float)):
+                total += float(elapsed)
+                found = True
+        if found:
+            return total
+    return None
+
+
+def _run_variant(
+    name: str,
+    ssd: SSD,
+    planner_cfg: PlannerConfig,
+    exec_cfg: ExecutionConfig,
+) -> VariantResult:
+    try:
+        planned = plan(ssd, planner_cfg)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return VariantResult(
+            name=name,
+            ok=False,
+            wall_s=None,
+            planner_config=asdict(planner_cfg),
+            error=f"plan_failed: {exc}",
+        )
+
+    try:
+        exec_payload = execute_ssd(planned, exec_cfg)
+        wall = _extract_wall_elapsed(exec_payload)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return VariantResult(
+            name=name,
+            ok=False,
+            wall_s=None,
+            planner_config=asdict(planner_cfg),
+            plan=planned.to_dict(),
+            error=f"execute_failed: {exc}",
+        )
+
+    return VariantResult(
+        name=name,
+        ok=True,
+        wall_s=wall,
+        planner_config=asdict(planner_cfg),
+        plan=planned.to_dict(),
+        execution=exec_payload,
+    )
+
+
+def _format_label(params: MutableMapping[str, Any]) -> str:
+    n = int(params.get("num_qubits", 0))
+    blocks = int(params.get("num_blocks", 0))
+    return f"n={n}, blocks={blocks}"
+
+
+def _make_runtime_plot(
+    records: List[Dict[str, Any]],
+    *,
+    out_path: Path,
+    title: str,
+) -> None:
+    labels = []
+    rel_full, rel_nodisjoint, rel_nohybrid = [], [], []
+
+    for rec in records:
+        params = rec.get("params", {})
+        variants = rec.get("variants", {})
+        labels.append(_format_label(params))
+
+        def _time(key: str) -> float:
+            data = variants.get(key, {})
+            if not isinstance(data, MutableMapping):
+                return math.nan
+            if data.get("ok") is False:
+                return math.nan
+            wall = data.get("wall_elapsed_s")
+            return float(wall) if isinstance(wall, (int, float)) else math.nan
+
+        t_full = _time("full")
+        t_nodisjoint = _time("no_disjoint")
+        t_nohybrid = _time("no_hybrid")
+
+        if math.isnan(t_full) or t_full == 0.0:
+            rel_full.append(math.nan)
+            rel_nodisjoint.append(math.nan)
+            rel_nohybrid.append(math.nan)
+        else:
+            rel_full.append(1.0)
+            rel_nodisjoint.append(
+                t_nodisjoint / t_full if not math.isnan(t_nodisjoint) else math.nan
+            )
+            rel_nohybrid.append(
+                t_nohybrid / t_full if not math.isnan(t_nohybrid) else math.nan
+            )
+
+    x = np.arange(len(labels))
+    width = 0.25
+
+    plt.figure(figsize=(max(8, len(labels) * 1.5), 5))
+    plt.bar(
+        x - width,
+        rel_full,
+        width,
+        label="Full QuASAr",
+        color=PASTEL_COLORS.get("tableau"),
+        edgecolor=EDGE_COLOR,
+    )
+    plt.bar(
+        x,
+        rel_nodisjoint,
+        width,
+        label="No disjoint partitioning",
+        color=PASTEL_COLORS.get("sv"),
+        edgecolor=EDGE_COLOR,
+    )
+    plt.bar(
+        x + width,
+        rel_nohybrid,
+        width,
+        label="No hybrid splitting",
+        color=PASTEL_COLORS.get("dd"),
+        edgecolor=EDGE_COLOR,
+    )
+
+    plt.xticks(x, labels, rotation=25, ha="right")
+    plt.ylabel("Relative runtime vs full QuASAr")
+    plt.title(title)
+    plt.axhline(1.0, color=EDGE_COLOR, linestyle="--", linewidth=1.0, alpha=0.6)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+def _make_relative_plot(
+    records: List[Dict[str, Any]],
+    *,
+    out_path: Path,
+    title: str,
+) -> None:
+    labels = []
+    slowdown_disjoint, slowdown_hybrid = [], []
+
+    for rec in records:
+        params = rec.get("params", {})
+        variants = rec.get("variants", {})
+        labels.append(_format_label(params))
+
+        def _wall(key: str) -> Optional[float]:
+            data = variants.get(key, {})
+            if not isinstance(data, MutableMapping):
+                return None
+            if data.get("ok") is False:
+                return None
+            wall = data.get("wall_elapsed_s")
+            return float(wall) if isinstance(wall, (int, float)) else None
+
+        full = _wall("full")
+        nd = _wall("no_disjoint")
+        nh = _wall("no_hybrid")
+
+        if full is None or full == 0:
+            slowdown_disjoint.append(math.nan)
+            slowdown_hybrid.append(math.nan)
+        else:
+            slowdown_disjoint.append(nd / full if nd is not None else math.nan)
+            slowdown_hybrid.append(nh / full if nh is not None else math.nan)
+
+    x = np.arange(len(labels))
+    width = 0.35
+
+    plt.figure(figsize=(max(8, len(labels) * 1.5), 5))
+    plt.bar(
+        x - width / 2,
+        slowdown_disjoint,
+        width,
+        label="No disjoint / Full",
+        color=PASTEL_COLORS.get("sv"),
+        edgecolor=EDGE_COLOR,
+    )
+    plt.bar(
+        x + width / 2,
+        slowdown_hybrid,
+        width,
+        label="No hybrid / Full",
+        color=PASTEL_COLORS.get("dd"),
+        edgecolor=EDGE_COLOR,
+    )
+
+    plt.axhline(1.0, color=EDGE_COLOR, linestyle="--", linewidth=1.0, alpha=0.6)
+    plt.xticks(x, labels, rotation=25, ha="right")
+    plt.ylabel("Slowdown vs full QuASAr")
+    plt.title(title)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an ablation study on QuASAr's partitioning components",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--n", "--num-qubits", nargs="+", type=int, dest="num_qubits", required=True)
+    parser.add_argument("--num-blocks", type=int, default=4, help="Number of disjoint blocks per circuit")
+    parser.add_argument("--tail-depth", type=int, default=24, help="Depth of diagonal tails inside each block")
+    parser.add_argument("--angle-scale", type=float, default=0.1, help="Rotation angle scale for diagonal tails")
+    parser.add_argument("--sparsity", type=float, default=0.10, help="RZ sparsity inside diagonal tails")
+    parser.add_argument("--bandwidth", type=int, default=2, help="CZ bandwidth inside diagonal tails")
+    parser.add_argument("--seed", type=int, default=None, help="Base seed for circuit construction")
+    parser.add_argument("--conv-factor", type=float, default=64.0, help="Conversion amortisation factor")
+    parser.add_argument("--twoq-factor", type=float, default=4.0, help="Statevector two-qubit gate factor")
+    parser.add_argument("--max-ram-gb", type=float, default=64.0, help="RAM budget for planning/execution")
+    parser.add_argument("--sv-ampops-per-sec", type=float, default=None, help="Override SV baseline speed (optional)")
+    parser.add_argument("--out-dir", type=str, default="ablation_runs", help="Directory to store outputs")
+    parser.add_argument("--json-name", type=str, default="ablation_results.json", help="Name of the JSON summary file")
+    parser.add_argument(
+        "--times-fig", type=str, default="ablation_relative_runtime.png", help="Filename for the relative runtime bar chart"
+    )
+    parser.add_argument(
+        "--relative-fig", type=str, default="ablation_slowdown.png", help="Filename for the slowdown bar chart"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    exec_cfg = ExecutionConfig(max_ram_gb=float(args.max_ram_gb))
+    records: List[Dict[str, Any]] = []
+
+    t_start = time.time()
+    combos = list(enumerate(args.num_qubits, start=1))
+    total = len(combos)
+
+    for index, n in combos:
+        seed = _ensure_seed(args.seed, index=index)
+        params = {
+            "num_qubits": int(n),
+            "num_blocks": int(args.num_blocks),
+            "tail_depth": int(args.tail_depth),
+            "angle_scale": float(args.angle_scale),
+            "sparsity": float(args.sparsity),
+            "bandwidth": int(args.bandwidth),
+            "seed": seed,
+        }
+        print(f"[{index}/{total}] Building circuit with params: {params}")
+
+        circ = disjoint_preps_plus_tails(
+            num_qubits=params["num_qubits"],
+            num_blocks=params["num_blocks"],
+            block_prep="ghz",
+            tail_kind="diag",
+            tail_depth=params["tail_depth"],
+            angle_scale=params["angle_scale"],
+            sparsity=params["sparsity"],
+            bandwidth=params["bandwidth"],
+            seed=params["seed"],
+        )
+
+        analysis = analyze(circ)
+        planner_base = dict(
+            max_ram_gb=float(args.max_ram_gb),
+            conv_amp_ops_factor=float(args.conv_factor),
+            sv_twoq_factor=float(args.twoq_factor),
+        )
+
+        variants: Dict[str, VariantResult] = {}
+
+        cfg_full = PlannerConfig(**planner_base)
+        variants["full"] = _run_variant("full", analysis.ssd, cfg_full, exec_cfg)
+
+        merged_ssd = _collapse_to_single_partition(
+            circ,
+            analysis.metrics_global,
+            total_qubits=params["num_qubits"],
+        )
+        cfg_nodisjoint = PlannerConfig(**planner_base)
+        variants["no_disjoint"] = _run_variant("no_disjoint", merged_ssd, cfg_nodisjoint, exec_cfg)
+
+        cfg_nohybrid = PlannerConfig(**planner_base, hybrid_clifford_tail=False)
+        variants["no_hybrid"] = _run_variant("no_hybrid", analysis.ssd, cfg_nohybrid, exec_cfg)
+
+        print(
+            "    -> times (s):",
+            {k: (v.wall_s if v.ok else None) for k, v in variants.items()},
+        )
+
+        try:
+            baselines = run_baselines(
+                circ,
+                which=["tableau", "sv", "dd"],
+                per_partition=False,
+                max_ram_gb=float(args.max_ram_gb),
+                sv_ampops_per_sec=args.sv_ampops_per_sec,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            baselines = {"error": str(exc)}
+
+        records.append(
+            {
+                "params": params,
+                "variants": {name: result.to_json() for name, result in variants.items()},
+                "baselines": baselines,
+            }
+        )
+
+    summary = {
+        "meta": {
+            "created_at": time.time(),
+            "args": vars(args),
+            "elapsed_s": time.time() - t_start,
+        },
+        "cases": records,
+    }
+
+    json_path = out_dir / args.json_name
+    with json_path.open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+    print(f"Wrote JSON summary to {json_path}")
+
+    if records:
+        times_path = out_dir / args.times_fig
+        _make_runtime_plot(records, out_path=times_path, title="QuASAr ablation study: relative runtime")
+        print(f"Wrote runtime bar chart to {times_path}")
+
+        rel_path = out_dir / args.relative_fig
+        _make_relative_plot(records, out_path=rel_path, title="QuASAr ablation study: slowdown vs full")
+        print(f"Wrote slowdown bar chart to {rel_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- normalise the ablation runtime bar chart so every variant is shown relative to full QuASAr
- document the normalisation and tweak the default runtime chart filename/title accordingly

## Testing
- python -m scripts.run_ablation_study --help

------
https://chatgpt.com/codex/tasks/task_e_68e4613b789c83218b9f15c08a570c0f