### PR TITLE
Add decision diagram cost model and hybrid playground

### DIFF
--- a/quasar/cost_estimator.py
+++ b/quasar/cost_estimator.py
@@ -1,5 +1,6 @@
 
 from __future__ import annotations
+import math
 from dataclasses import dataclass
 from typing import Dict, Any
 
@@ -8,6 +9,13 @@ class CostParams:
     conv_amp_ops_factor: float = 64.0
     sv_twoq_factor: float = 4.0
     tableau_prefix_unit_cost: float = 0.0
+    dd_gate_node_factor: float = 0.05
+    dd_frontier_weight: float = 0.35
+    dd_rotation_weight: float = 0.1
+    dd_twoq_weight: float = 0.2
+    dd_sparsity_discount: float = 0.6
+    dd_modifier_floor: float = 0.05
+    dd_base_cost: float = 0.0
 
 class CostEstimator:
     def __init__(self, params: CostParams | None = None) -> None:
@@ -26,6 +34,38 @@ class CostEstimator:
     def conversion_cost(self, n: int) -> float:
         return self.params.conv_amp_ops_factor * self._amps(n)
 
+    def decision_diagram_cost(
+        self,
+        *,
+        n: int,
+        num_gates: int,
+        twoq: int,
+        rotation_count: int,
+        sparsity: float,
+    ) -> float:
+        if n <= 0 or num_gates <= 0:
+            return float(self.params.dd_base_cost)
+
+        frontier = max(1, int(n))
+        base_nodes = frontier * max(1.0, math.log2(frontier + 1.0))
+        gate_factor = max(1.0, math.log2(num_gates + 1.0))
+        rotation_density = rotation_count / max(1, num_gates)
+        twoq_density = twoq / max(1, num_gates)
+        sparsity = min(max(float(sparsity), 0.0), 1.0)
+
+        modifier = 1.0
+        modifier += self.params.dd_frontier_weight * math.log2(frontier + 1.0)
+        modifier += self.params.dd_rotation_weight * rotation_density
+        modifier += self.params.dd_twoq_weight * twoq_density
+        modifier -= self.params.dd_sparsity_discount * sparsity
+        modifier = max(self.params.dd_modifier_floor, modifier)
+
+        cost = (
+            self.params.dd_base_cost
+            + self.params.dd_gate_node_factor * num_gates * base_nodes * gate_factor * modifier
+        )
+        return float(cost)
+
     def compare_clifford_prefix_tail(self, *, n: int, one_pre: int, two_pre: int, one_tail: int, two_tail: int) -> Dict[str, Any]:
         sv_total  = self.sv_cost(n, one_pre + one_tail, two_pre + two_tail)
         sv_tail   = self.sv_cost(n, one_tail, two_tail)
@@ -39,6 +79,60 @@ class CostEstimator:
             "tableau_prefix": float(tab_pre),
             "hybrid_total": float(hybrid),
             "hybrid_better": bool(hybrid < sv_total),
+        }
+
+    def compare_clifford_prefix_dd_tail(
+        self,
+        *,
+        n: int,
+        prefix_metrics: Dict[str, Any],
+        tail_metrics: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        pre_twoq = int(prefix_metrics.get("two_qubit_gates", 0) or 0)
+        pre_total = int(prefix_metrics.get("num_gates", 0) or 0)
+        pre_oneq = max(pre_total - pre_twoq, 0)
+        pre_rot = int(prefix_metrics.get("rotation_count", 0) or 0)
+        pre_sparsity = float(prefix_metrics.get("sparsity", 0.0) or 0.0)
+
+        tail_twoq = int(tail_metrics.get("two_qubit_gates", 0) or 0)
+        tail_total = int(tail_metrics.get("num_gates", 0) or 0)
+        tail_oneq = max(tail_total - tail_twoq, 0)
+        tail_rot = int(tail_metrics.get("rotation_count", 0) or 0)
+        tail_sparsity = float(tail_metrics.get("sparsity", 0.0) or 0.0)
+
+        total_twoq = pre_twoq + tail_twoq
+        total_rot = pre_rot + tail_rot
+        total_gates = pre_total + tail_total
+        combined_sparsity = min(pre_sparsity, tail_sparsity)
+
+        dd_total = self.decision_diagram_cost(
+            n=n,
+            num_gates=total_gates,
+            twoq=total_twoq,
+            rotation_count=total_rot,
+            sparsity=combined_sparsity,
+        )
+        dd_tail = self.decision_diagram_cost(
+            n=n,
+            num_gates=tail_total,
+            twoq=tail_twoq,
+            rotation_count=tail_rot,
+            sparsity=tail_sparsity,
+        )
+
+        tab_pre = self.tableau_prefix_cost(n, pre_oneq, pre_twoq)
+        conv = self.conversion_cost(n)
+        hybrid = tab_pre + conv + dd_tail
+
+        return {
+            "dd_total": float(dd_total),
+            "dd_tail": float(dd_tail),
+            "conversion": float(conv),
+            "tableau_prefix": float(tab_pre),
+            "hybrid_total": float(hybrid),
+            "hybrid_better": bool(hybrid < dd_total),
+            "prefix_sparsity": float(pre_sparsity),
+            "tail_sparsity": float(tail_sparsity),
         }
 
     @classmethod

--- a/quasar/gate_metrics.py
+++ b/quasar/gate_metrics.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+"""Utility helpers for extracting gate metrics from Qiskit circuits."""
+
+from typing import Any, Dict, Iterable, Tuple
+
+__all__ = [
+    "CLIFFORD_GATES",
+    "ROTATION_GATES",
+    "BRANCHING_GATES",
+    "gate_name",
+    "is_clifford_gate",
+    "estimate_sparsity",
+    "circuit_metrics",
+]
+
+CLIFFORD_GATES = {
+    "i",
+    "x",
+    "y",
+    "z",
+    "h",
+    "s",
+    "sdg",
+    "cx",
+    "cz",
+    "swap",
+}
+
+ROTATION_GATES = {
+    "rx",
+    "ry",
+    "rz",
+    "rxx",
+    "ryy",
+    "rzz",
+    "crx",
+    "cry",
+    "crz",
+    "rzx",
+}
+
+# Heuristic set of gates that branch the state when applied without controls.
+BRANCHING_GATES = {
+    "h",
+    "rx",
+    "ry",
+    "u",
+    "u2",
+    "u3",
+}
+
+
+def gate_name(inst: Any) -> str:
+    """Return a lowercase instruction name for ``inst``.
+
+    The helper mirrors the inline logic previously duplicated in a number of
+    modules and gracefully falls back to ``str(inst)`` when the instruction does
+    not expose a ``name`` attribute.
+    """
+
+    try:
+        return inst.name.lower()  # type: ignore[attr-defined]
+    except Exception:
+        return str(inst).lower()
+
+
+def is_clifford_gate(name: str) -> bool:
+    """Return ``True`` when ``name`` corresponds to a Clifford gate."""
+
+    return name in CLIFFORD_GATES
+
+
+def _branching_effect(name: str, arity: int) -> Tuple[bool, bool]:
+    """Return branching properties for ``name`` with the given ``arity``.
+
+    The returned tuple is ``(branches, controlled_branch)`` where ``branches``
+    is ``True`` when the gate doubles the number of amplitudes outright and
+    ``controlled_branch`` marks controlled variants that only add a single extra
+    amplitude.  The heuristic intentionally errs on the conservative side and
+    treats unknown operations as non-branching.
+    """
+
+    base = name.lstrip("c")
+    if base not in BRANCHING_GATES:
+        return False, False
+    if arity <= 1:
+        return True, False
+    return False, True
+
+
+def estimate_sparsity(num_qubits: int, ops: Iterable[Tuple[Any, Any, Any]]) -> float:
+    """Return a heuristic sparsity estimate for a circuit fragment.
+
+    ``ops`` is expected to be an iterable of ``(instruction, qargs, cargs)``
+    tuples as provided by ``QuantumCircuit.data``.  The heuristic tracks an
+    estimate of the number of non-zero amplitudes created from ``|0…0>`` by
+    counting the branching operations.  Uncontrolled branching doubles the
+    count while controlled versions add a single amplitude.  The result is
+    clamped to ``[0.0, 1.0]`` where ``1.0`` corresponds to a completely sparse
+    state (single amplitude) and ``0.0`` denotes a fully populated state.
+    """
+
+    if num_qubits <= 0:
+        return 1.0
+
+    full_dim = 1 << num_qubits
+    nnz = 1
+    for inst, qargs, _ in ops:
+        name = gate_name(inst)
+        branches, controlled = _branching_effect(name, len(qargs))
+        if branches:
+            nnz = min(full_dim, nnz * 2)
+        elif controlled:
+            nnz = min(full_dim, nnz + 1)
+    if nnz >= full_dim and num_qubits <= 12:
+        slack = max(1, full_dim // max(4, 2 * num_qubits))
+        nnz = max(full_dim - slack, 1)
+    sparsity = 1.0 - nnz / full_dim
+    if sparsity < 0.0:
+        return 0.0
+    if sparsity > 1.0:
+        return 1.0
+    return sparsity
+
+
+def circuit_metrics(circ: Any) -> Dict[str, Any]:
+    """Collect lightweight metrics for ``circ``.
+
+    The helper mirrors the information required by the planner and cost
+    estimator.  The implementation is written against the Qiskit interface but
+    only relies on the generic ``.data`` and ``.num_qubits`` attributes, making
+    it inexpensive to reuse in tests.
+    """
+
+    total = 0
+    cliff = 0
+    twoq = 0
+    t_count = 0
+    rotations = 0
+    for inst, qargs, _ in circ.data:
+        name = gate_name(inst)
+        total += 1
+        if name in {"t", "tdg"}:
+            t_count += 1
+        if len(qargs) >= 2:
+            twoq += 1
+        if name in ROTATION_GATES:
+            rotations += 1
+        if is_clifford_gate(name):
+            cliff += 1
+    is_clifford = bool(total > 0 and cliff == total and t_count == 0 and rotations == 0)
+    sparsity = estimate_sparsity(circ.num_qubits, circ.data)
+    return {
+        "num_qubits": circ.num_qubits,
+        "num_gates": total,
+        "clifford_gates": cliff,
+        "two_qubit_gates": twoq,
+        "t_count": t_count,
+        "rotation_count": rotations,
+        "is_clifford": is_clifford,
+        "depth": circ.depth(),
+        "sparsity": sparsity,
+    }

--- a/scripts/playground_clifford_dd.py
+++ b/scripts/playground_clifford_dd.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+from benchmarks.hybrid import clifford_prefix_rot_tail
+from quasar.cost_estimator import CostEstimator, CostParams
+from quasar.gate_metrics import circuit_metrics, gate_name, CLIFFORD_GATES
+
+
+def _split_at_first_nonclifford(qc) -> Optional[int]:
+    for idx, (inst, _, _) in enumerate(qc.data):
+        if gate_name(inst) not in CLIFFORD_GATES:
+            return idx
+    return None
+
+
+def _build_subcircuit_like(parent, ops: List[Any]):
+    from qiskit import QuantumCircuit
+
+    sub = QuantumCircuit(parent.num_qubits)
+    for inst, qargs, cargs in ops:
+        local_qargs = [sub.qubits[parent.find_bit(q).index] for q in qargs]
+        sub.append(inst, local_qargs, cargs)
+    sub.metadata = dict(getattr(parent, "metadata", {}) or {})
+    return sub
+
+
+def analyze_case(
+    *,
+    n: int,
+    depth: int,
+    cutoff: float,
+    angle_scale: float,
+    estimator: CostEstimator,
+    prefix_sparsity_min: float,
+    tail_sparsity_min: float,
+) -> Dict[str, Any]:
+    qc = clifford_prefix_rot_tail(
+        num_qubits=n, depth=depth, cutoff=cutoff, angle_scale=angle_scale, seed=42
+    )
+    split_idx = _split_at_first_nonclifford(qc)
+    if split_idx is None:
+        return {
+            "feasible": False,
+            "reason": "no_nonclifford_tail",
+        }
+
+    pre_ops = qc.data[:split_idx]
+    tail_ops = qc.data[split_idx:]
+    prefix = _build_subcircuit_like(qc, pre_ops)
+    tail = _build_subcircuit_like(qc, tail_ops)
+    prefix_metrics = circuit_metrics(prefix)
+    tail_metrics = circuit_metrics(tail)
+
+    cmp = estimator.compare_clifford_prefix_dd_tail(
+        n=n, prefix_metrics=prefix_metrics, tail_metrics=tail_metrics
+    )
+    norm = 1 << n
+    dd_total_norm = cmp["dd_total"] / norm
+    hybrid_norm = cmp["hybrid_total"] / norm
+    speedup = (
+        cmp["dd_total"] / cmp["hybrid_total"]
+        if cmp["hybrid_total"] > 0
+        else float("inf")
+    )
+
+    prefix_sparse_ok = prefix_metrics["sparsity"] >= prefix_sparsity_min
+    tail_sparse_ok = tail_metrics["sparsity"] >= tail_sparsity_min
+    feasible = bool(cmp["hybrid_better"] and prefix_sparse_ok and tail_sparse_ok)
+
+    return {
+        "feasible": feasible,
+        "dd_total_norm": dd_total_norm,
+        "hybrid_norm": hybrid_norm,
+        "speedup_vs_dd": speedup,
+        "prefix_sparsity": prefix_metrics["sparsity"],
+        "tail_sparsity": tail_metrics["sparsity"],
+        "prefix_sparse_ok": prefix_sparse_ok,
+        "tail_sparse_ok": tail_sparse_ok,
+        "split_index": split_idx,
+    }
+
+
+def _is_interactive_backend() -> bool:
+    return matplotlib.get_backend() in {
+        "TkAgg",
+        "QtAgg",
+        "Qt5Agg",
+        "MacOSX",
+        "GTK3Agg",
+        "GTK4Agg",
+        "wxAgg",
+        "WebAgg",
+        "nbAgg",
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Playground for tableau→DD hybrids: sweep depths for random circuits "
+            "with a Clifford prefix and report estimated speedups."
+        )
+    )
+    ap.add_argument("--n", type=int, nargs="+", default=[8, 10, 12, 14], help="Qubit counts to sweep.")
+    ap.add_argument("--min-depth", type=int, default=50, help="Minimum total depth (inclusive).")
+    ap.add_argument("--max-depth", type=int, default=400, help="Maximum total depth (inclusive).")
+    ap.add_argument("--step", type=int, default=1, help="Depth step size.")
+    ap.add_argument(
+        "--cutoff",
+        type=float,
+        nargs="+",
+        default=[0.8],
+        help="Clifford prefix fraction (e.g. 0.8 = 80% prefix).",
+    )
+    ap.add_argument("--angle-scale", type=float, default=0.1)
+    ap.add_argument("--conv-factor", type=float, default=64.0)
+    ap.add_argument("--twoq-factor", type=float, default=4.0)
+    ap.add_argument("--prefix-sparsity-min", type=float, default=0.5)
+    ap.add_argument("--tail-sparsity-min", type=float, default=0.2)
+    ap.add_argument(
+        "--target-speedup",
+        type=float,
+        default=1.0,
+        help="Reference speedup line (DD_cost / Hybrid_cost).",
+    )
+    ap.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="If set, save the generated plot to this path instead of displaying it.",
+    )
+    ap.add_argument(
+        "--save-json",
+        type=str,
+        default=None,
+        help="If set, store the sweep data as JSON for later analysis.",
+    )
+    args = ap.parse_args()
+
+    if args.min_depth < 1 or args.max_depth < args.min_depth:
+        raise SystemExit("--max-depth must be >= --min-depth and both >= 1.")
+    if args.step < 1:
+        raise SystemExit("--step must be >= 1")
+
+    depths = list(range(int(args.min_depth), int(args.max_depth) + 1, int(args.step)))
+    estimator = CostEstimator(
+        CostParams(
+            conv_amp_ops_factor=args.conv_factor,
+            sv_twoq_factor=args.twoq_factor,
+        )
+    )
+
+    records = []
+    print(
+        "n,cutoff,depth,feasible,speedup,dd_total_norm,hybrid_norm," "prefix_sparsity,tail_sparsity"
+    )
+    for cutoff in args.cutoff:
+        for n in args.n:
+            series_speedups: List[float] = []
+            series_depths: List[int] = []
+            feasible_mask: List[bool] = []
+            for depth in depths:
+                res = analyze_case(
+                    n=n,
+                    depth=depth,
+                    cutoff=cutoff,
+                    angle_scale=args.angle_scale,
+                    estimator=estimator,
+                    prefix_sparsity_min=args.prefix_sparsity_min,
+                    tail_sparsity_min=args.tail_sparsity_min,
+                )
+                feasible = res.get("feasible", False)
+                speedup = res.get("speedup_vs_dd", float("nan"))
+                if not feasible:
+                    series_speedups.append(float("nan"))
+                else:
+                    series_speedups.append(speedup)
+                feasible_mask.append(bool(feasible))
+                series_depths.append(depth)
+                dd_norm = res.get("dd_total_norm")
+                hyb_norm = res.get("hybrid_norm")
+                pref_sp = res.get("prefix_sparsity")
+                tail_sp = res.get("tail_sparsity")
+                speedup_str = f"{speedup:.3f}" if feasible else ""
+                dd_str = "" if dd_norm is None else f"{dd_norm:.3f}"
+                hyb_str = "" if hyb_norm is None else f"{hyb_norm:.3f}"
+                pref_str = "" if pref_sp is None else f"{pref_sp:.3f}"
+                tail_str = "" if tail_sp is None else f"{tail_sp:.3f}"
+                print(
+                    f"{n},{cutoff},{depth},{int(feasible)},{speedup_str},"
+                    f"{dd_str},{hyb_str},{pref_str},{tail_str}"
+                )
+            records.append(
+                {
+                    "n": n,
+                    "cutoff": cutoff,
+                    "depths": series_depths,
+                    "speedups": series_speedups,
+                    "feasible": feasible_mask,
+                }
+            )
+
+    if args.save_json:
+        payload = {
+            "meta": {
+                "timestamp": int(time.time()),
+                "params": {
+                    "n_list": args.n,
+                    "min_depth": args.min_depth,
+                    "max_depth": args.max_depth,
+                    "step": args.step,
+                    "cutoff_list": args.cutoff,
+                    "angle_scale": args.angle_scale,
+                    "conv_factor": args.conv_factor,
+                    "twoq_factor": args.twoq_factor,
+                    "prefix_sparsity_min": args.prefix_sparsity_min,
+                    "tail_sparsity_min": args.tail_sparsity_min,
+                    "target_speedup": args.target_speedup,
+                },
+            },
+            "records": records,
+        }
+        with open(args.save_json, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        print(f"Wrote sweep JSON: {args.save_json}")
+
+    plt.figure(figsize=(9, 5))
+    for rec in records:
+        label = f"n={rec['n']}, cutoff={float(rec['cutoff']):.2f}"
+        plt.plot(rec["depths"], rec["speedups"], marker="o", linewidth=1.5, label=label)
+    if args.target_speedup and args.target_speedup > 0:
+        plt.axhline(args.target_speedup, linestyle="--", linewidth=1, color="gray")
+    plt.xlabel("Depth (layers)")
+    plt.ylabel("Speedup (DD_cost / Hybrid_cost)")
+    plt.title(
+        "Tableau→DD hybrid speedup vs depth\n"
+        f"conv={args.conv_factor}, twoq={args.twoq_factor}, angle_scale={args.angle_scale},"
+        f" prefix≥{args.prefix_sparsity_min:.2f}, tail≥{args.tail_sparsity_min:.2f}"
+    )
+    plt.grid(True, alpha=0.3)
+    plt.legend()
+    plt.tight_layout()
+
+    if args.out:
+        plt.savefig(args.out, dpi=200, bbox_inches="tight")
+        print(f"Wrote figure: {args.out}")
+    else:
+        if _is_interactive_backend():
+            plt.show()
+        else:
+            timestamp = int(time.time())
+            fallback = f"dd_hybrid_speedup_{timestamp}.png"
+            plt.savefig(fallback, dpi=200, bbox_inches="tight")
+            print(f"Saved figure to {fallback}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_clifford_tail.py
+++ b/test_clifford_tail.py
@@ -37,11 +37,13 @@ def test_hybrid_prefix_metrics():
     assert prefix.metrics["is_clifford"] is True
     assert prefix.metrics["rotation_count"] == 0
     assert prefix.metrics["clifford_gates"] == 3
+    assert 0.0 <= prefix.metrics["sparsity"] <= 1.0
 
     assert tail.metrics["num_gates"] == 3
     assert tail.metrics["rotation_count"] == 2
     assert tail.metrics["is_clifford"] is False
     assert tail.metrics["clifford_gates"] == 1
+    assert 0.0 <= tail.metrics["sparsity"] <= 1.0
 
 
 def test_hybrid_partition_qubits_are_local():
@@ -73,7 +75,7 @@ def test_hybrid_partition_qubits_are_local():
 
         # Ensure all qubits in the circuit come from its own registers (no foreign qubits)
         assert len(circuit.qregs) == 1
-        assert tuple(circuit.qregs[0]) == circuit.qubits
+        assert tuple(circuit.qregs[0]) == tuple(circuit.qubits)
 
         # Ensure the mapping points to the circuit's qubit tuple
         for _, local_idx in mapping.items():

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from quasar.cost_estimator import CostEstimator, CostParams
+
+
+def test_compare_clifford_prefix_dd_tail_basic():
+    est = CostEstimator(CostParams())
+    prefix = {
+        "num_gates": 4,
+        "two_qubit_gates": 2,
+        "rotation_count": 0,
+        "sparsity": 0.75,
+    }
+    tail = {
+        "num_gates": 6,
+        "two_qubit_gates": 3,
+        "rotation_count": 2,
+        "sparsity": 0.5,
+    }
+    res = est.compare_clifford_prefix_dd_tail(n=5, prefix_metrics=prefix, tail_metrics=tail)
+    assert set(res.keys()) >= {
+        "dd_total",
+        "dd_tail",
+        "conversion",
+        "tableau_prefix",
+        "hybrid_total",
+        "hybrid_better",
+        "prefix_sparsity",
+        "tail_sparsity",
+    }
+    assert res["dd_total"] >= res["dd_tail"]
+    assert res["prefix_sparsity"] == prefix["sparsity"]
+    assert res["tail_sparsity"] == tail["sparsity"]


### PR DESCRIPTION
## Summary
- add shared gate-metric helpers (including sparsity estimation) and integrate them into the analyzer and planner
- extend the cost estimator with a decision diagram model plus a Tableau→DD hybrid comparison
- add a Tableau→DD hybrid playground script and tests covering the new estimator API

## Testing
- pytest tests/test_cost_estimator.py test_clifford_tail.py

------
https://chatgpt.com/codex/tasks/task_e_68e46ad89808832185507ecb47f1e8dc