### PR TITLE
Enhance ablation circuits with hybrid sparse tails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -204,7 +204,17 @@ for the output image path.
 
 `scripts/run_ablation_study.py` automates the hybrid/disjoint ablation runs
 referenced in the paper. It sweeps a list of qubit counts, constructs the
-matching block-disjoint hybrid circuits, and benchmarks three QuASAr variants:
+matching block-disjoint hybrid circuits, and benchmarks three QuASAr variants.
+Each generated circuit intentionally combines all optimisation opportunities
+used by QuASAr:
+
+- multiple disjoint qubit subsets prepared independently,
+- a Clifford-only prefix that transitions into non-Clifford (diagonal) tails,
+  and
+- sparse diagonal tails that encourage decision diagram execution when
+  available.
+
+The benchmarked variants are:
 
 - **Full QuASAr** — disjoint partitioning and hybrid tail splitting enabled
   (baseline).
@@ -222,11 +232,11 @@ Typical invocation:
 ```bash
 python -m scripts.run_ablation_study \
     --n 16 24 32 \
-    --num-blocks 4 \
+    --num-blocks 2 \
     --out-dir ablation_runs \
-    --json-name ghz_blocks.json \
-    --times-fig ghz_relative_runtime.png \
-    --relative-fig ghz_slowdown.png
+    --json-name hybrid_disjoint_results.json \
+    --times-fig hybrid_relative_runtime.png \
+    --relative-fig hybrid_slowdown.png
 ```
 
 Key flags:


### PR DESCRIPTION
## Summary
- extend the disjoint benchmark builder with explicit hybrid tails that keep the Clifford prefix sparse before transitioning into diagonal rotations
- teach the planner to prefer the DD backend for sparse hybrid tails and record richer planner metadata
- update the ablation script/documentation to use the hybrid circuit family, validate that all backends are exercised, and refresh defaults/output names

## Testing
- `python - <<'PY'
from benchmarks.disjoint import disjoint_preps_plus_tails
from quasar.analyzer import analyze
from quasar.planner import plan, PlannerConfig

circ = disjoint_preps_plus_tails(num_qubits=32, num_blocks=4, block_prep='ghz', tail_kind='hybrid', tail_depth=24, angle_scale=0.1, sparsity=0.1, bandwidth=2, seed=24)
ssd = plan(analyze(circ).ssd, PlannerConfig())
for node in ssd.partitions:
    print(node.id, node.backend, node.meta.get('chain_id'), node.meta.get('planner_reason'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68e4abbc0e608321939bb32775ed5d0e