### PR TITLE
Adjust ablation runtime plot scaling and annotations

### DIFF
--- a/scripts/run_ablation_study.py
+++ b/scripts/run_ablation_study.py
@@ -350,8 +350,8 @@ def _make_runtime_plot(
     x = np.arange(len(labels))
     width = 0.25
 
-    plt.figure(figsize=(max(8, len(labels) * 1.5), 5))
-    plt.bar(
+    fig, ax = plt.subplots(figsize=(max(8, len(labels) * 1.5), 5))
+    bars_full = ax.bar(
         x - width,
         rel_full,
         width,
@@ -359,7 +359,7 @@ def _make_runtime_plot(
         color=PASTEL_COLORS.get("tableau"),
         edgecolor=EDGE_COLOR,
     )
-    plt.bar(
+    bars_nodisjoint = ax.bar(
         x,
         rel_nodisjoint,
         width,
@@ -367,7 +367,7 @@ def _make_runtime_plot(
         color=PASTEL_COLORS.get("sv"),
         edgecolor=EDGE_COLOR,
     )
-    plt.bar(
+    bars_nohybrid = ax.bar(
         x + width,
         rel_nohybrid,
         width,
@@ -376,14 +376,32 @@ def _make_runtime_plot(
         edgecolor=EDGE_COLOR,
     )
 
-    plt.xticks(x, labels, rotation=25, ha="right")
-    plt.ylabel("Relative runtime vs full QuASAr")
-    plt.title(title)
-    plt.axhline(1.0, color=EDGE_COLOR, linestyle="--", linewidth=1.0, alpha=0.6)
-    plt.legend()
-    plt.tight_layout()
-    plt.savefig(out_path, dpi=200)
-    plt.close()
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=25, ha="right")
+    ax.set_ylabel("Relative runtime vs full QuASAr")
+    ax.set_title(title)
+    ax.axhline(1.0, color=EDGE_COLOR, linestyle="--", linewidth=1.0, alpha=0.6)
+    ax.set_yscale("log")
+
+    for bars, values in ((bars_nodisjoint, rel_nodisjoint), (bars_nohybrid, rel_nohybrid)):
+        for bar, value in zip(bars, values):
+            if value is None or math.isnan(value) or value <= 0:
+                continue
+            text = f"{value:.1f}×"
+            text_y = value * 1.1
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                text_y,
+                text,
+                ha="center",
+                va="bottom",
+                fontsize=10,
+            )
+
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=200)
+    plt.close(fig)
 
 
 def _make_memory_plot(


### PR DESCRIPTION
## Summary
- switch the runtime ablation chart to the matplotlib OO API and log-scale the y-axis
- add slowdown annotations above the non-baseline bars so their relative cost is explicit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ac7ca0548321acdf463e39795d31