### PR TITLE
Add sparse hybrid circuit option

### DIFF
--- a/plots/bar_clifford_tail.py
+++ b/plots/bar_clifford_tail.py
@@ -13,7 +13,11 @@ from .palette import EDGE_COLOR, FALLBACK_COLOR, PASTEL_COLORS
 
 COLORS = PASTEL_COLORS
 
-KINDS = {"clifford_plus_rot", "clifford_prefix_rot_tail"}
+KINDS = {
+    "clifford_plus_rot",
+    "clifford_prefix_rot_tail",
+    "sparse_clifford_prefix_sparse_tail",
+}
 
 def _load_cases(suite_dir: str) -> List[Dict[str, Any]]:
     cases = []


### PR DESCRIPTION
## Summary
- add a `sparse_clifford_prefix_sparse_tail` hybrid circuit generator with sparse Clifford prefixes and diagonal tails
tuned for DD backends
- update `bench_from_thresholds` to select the sparse generator via `--dd`, adjust suite metadata, and extend
plotting coverage for the new circuit kind
- remove the planner override hook that forced specific tail backends and update tests accordingly

## Testing
- PYTHONPATH=. pytest tests/test_bench_from_thresholds.py

------
https://chatgpt.com/codex/tasks/task_e_68e4d50aaa808321bce085a77f42859a