### PR TITLE
Add memory plot option to bar_disjoint CLI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -193,12 +193,14 @@ All plotters now live under `plots/`:
 - `plots/bar_disjoint.py` — parallel disjoint benchmark comparison. Produces a
   two-bar chart per `(n, blocks)` pair showing QuASAr's parallel runtime next to
   the best whole-circuit baseline with the simulator type encoded in the bar
-  colour.
+  colour. Pass `--memory-out` (or `--memory-out=auto` alongside `--out`) to also
+  render the memory comparison plot in a single invocation.
 - `plots/compare_total.py` — convenience helpers to compare total QuASAr vs
   baseline runtimes or visualise SSD partition timings.
 
 Each plotter accepts `--suite-dir` (directory with suite JSON files) and `--out`
-for the output image path.
+for the output image path; `bar_disjoint` additionally exposes `--memory-out`
+to render the memory comparison bars.
 
 ## Ablation study script
 

--- a/plots/bar_disjoint.py
+++ b/plots/bar_disjoint.py
@@ -494,9 +494,29 @@ def main() -> None:
     ap.add_argument("--suite-dir", type=str, required=True)
     ap.add_argument("--out", type=str, default=None)
     ap.add_argument("--title", type=str, default=None)
+    ap.add_argument(
+        "--memory-out",
+        type=str,
+        default=None,
+        help=(
+            "Optional output path for the memory comparison plot. Pass 'auto' to "
+            "derive the path from --out by appending '_memory' before the "
+            "extension."
+        ),
+    )
     args = ap.parse_args()
 
     make_plot(args.suite_dir, out=args.out, title=args.title)
+
+    memory_out = args.memory_out
+    if memory_out == "auto":
+        if not args.out:
+            raise SystemExit("--memory-out=auto requires --out to be specified")
+        root, ext = os.path.splitext(args.out)
+        memory_out = f"{root}_memory{ext}" if ext else f"{args.out}_memory"
+
+    if memory_out is not None:
+        make_memory_plot(args.suite_dir, out=memory_out, title=args.title)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend the bar_disjoint CLI with a --memory-out option (including an auto helper) to call make_memory_plot
- document the new memory plotting option in the plotting utilities section of the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e534f28c4483218923b658ee5f3fbd