### PR TITLE
Add parallel worker override to disjoint benchmark CLI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -166,6 +166,8 @@ Key options:
   than the configured limit.
 - As with the hybrid workflow, planner and baseline tuning flags are passed
   through to `suites/run_disjoint_suite.py`.
+- `--parallel-workers` controls how many worker processes QuASAr should use
+  when executing disjoint blocks in parallel (defaults to an automatic choice).
 
 #### Consolidated tables
 

--- a/scripts/make_figures_and_tables.py
+++ b/scripts/make_figures_and_tables.py
@@ -304,6 +304,8 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
         runner_args.extend(["--prep", args.prep])
     if args.sv_ampops_per_sec is not None:
         runner_args.extend(["--sv-ampops-per-sec", str(args.sv_ampops_per_sec)])
+    if args.parallel_workers is not None:
+        runner_args.extend(["--parallel-workers", str(args.parallel_workers)])
     if args.seed is not None:
         runner_args.extend(["--seed", str(args.seed)])
 
@@ -550,6 +552,12 @@ def build_parser() -> argparse.ArgumentParser:
     disjoint.add_argument("--seed", type=int, default=None, help="Random seed for circuit construction")
     disjoint.add_argument("--out", type=str, required=True, help="Path to the output bar chart file")
     disjoint.add_argument("--title", type=str, default=None, help="Optional figure title override")
+    disjoint.add_argument(
+        "--parallel-workers",
+        type=int,
+        default=None,
+        help="Override the number of parallel workers when executing disjoint blocks",
+    )
     disjoint.set_defaults(func=cmd_disjoint)
 
     # Table ------------------------------------------------------------------

--- a/suites/run_disjoint_suite.py
+++ b/suites/run_disjoint_suite.py
@@ -110,7 +110,10 @@ def run_case(
 
     if planned_ssd is not None:
         try:
-            exec_cfg = ExecutionConfig(max_ram_gb=float(args.max_ram_gb))
+            exec_cfg = ExecutionConfig(
+                max_ram_gb=float(args.max_ram_gb),
+                max_workers=int(args.parallel_workers) if args.parallel_workers is not None else 0,
+            )
             t0 = time.time()
             exec_payload = execute_ssd(planned_ssd, exec_cfg)
             elapsed = time.time() - t0
@@ -160,6 +163,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--twoq-factor", type=float, default=4.0, help="Statevector two-qubit gate factor")
     parser.add_argument("--max-ram-gb", type=float, default=64.0, help="RAM budget for planning/execution")
     parser.add_argument("--sv-ampops-per-sec", type=float, default=None, help="Override SV amp-ops/sec baseline speed")
+    parser.add_argument(
+        "--parallel-workers",
+        type=int,
+        default=0,
+        help="Number of parallel workers to use for executing disjoint blocks (0 = auto)",
+    )
     parser.add_argument("--seed", type=int, default=None, help="Optional RNG seed for circuit construction")
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- allow the make_figures disjoint sub-command to forward a --parallel-workers override
- wire the parallel worker setting through the disjoint suite runner and update the docs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5384c7dc08321805832e720de72b6