### PR TITLE
Ensure baseline timeouts use subprocess isolation

### DIFF
--- a/tests/test_baselines_runner.py
+++ b/tests/test_baselines_runner.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import multiprocessing
 import pathlib
 import sys
+import time
 from types import ModuleType
 from unittest import mock
 
@@ -13,49 +15,52 @@ def _ensure_stub(name: str, module: ModuleType) -> None:
         sys.modules[name] = module
 
 
-_numpy_stub = ModuleType("numpy")
-setattr(_numpy_stub, "array", lambda x, **_: x)
-setattr(_numpy_stub, "asarray", lambda x, **_: x)
-setattr(_numpy_stub, "complex128", complex)
-_ensure_stub("numpy", _numpy_stub)
+try:  # Prefer real numpy when available
+    import numpy  # noqa: F401
+except Exception:  # pragma: no cover - fallback for limited test environments
+    _numpy_stub = ModuleType("numpy")
+    setattr(_numpy_stub, "array", lambda x, **_: x)
+    setattr(_numpy_stub, "asarray", lambda x, **_: x)
+    setattr(_numpy_stub, "complex128", complex)
+    setattr(_numpy_stub, "pi", 3.141592653589793)
+    _ensure_stub("numpy", _numpy_stub)
 
+try:  # Prefer real qiskit when available
+    import qiskit  # noqa: F401
+except Exception:  # pragma: no cover - fallback when qiskit is missing
+    _qiskit_stub = ModuleType("qiskit")
 
-_qiskit_stub = ModuleType("qiskit")
+    class _StubQuantumCircuit:
+        def __init__(self, num_qubits: int):
+            self.num_qubits = num_qubits
 
+        def copy(self):
+            return self
 
-class _StubQuantumCircuit:
-    def __init__(self, num_qubits: int):
-        self.num_qubits = num_qubits
+        def save_statevector(self):
+            return None
 
-    def copy(self):
-        return self
+    setattr(_qiskit_stub, "QuantumCircuit", _StubQuantumCircuit)
+    _ensure_stub("qiskit", _qiskit_stub)
 
-    def save_statevector(self):
-        return None
+try:  # Prefer real qiskit-aer when available
+    import qiskit_aer  # noqa: F401
+except Exception:  # pragma: no cover - fallback when qiskit-aer is missing
+    _qiskit_aer_stub = ModuleType("qiskit_aer")
 
+    class _StubJob:
+        def result(self):  # pragma: no cover - not expected to be called
+            raise RuntimeError("stub")
 
-setattr(_qiskit_stub, "QuantumCircuit", _StubQuantumCircuit)
-_ensure_stub("qiskit", _qiskit_stub)
+    class _StubAerSimulator:
+        def __init__(self, **_):
+            pass
 
+        def run(self, *_args, **_kwargs):
+            return _StubJob()
 
-_qiskit_aer_stub = ModuleType("qiskit_aer")
-
-
-class _StubJob:
-    def result(self):  # pragma: no cover - not expected to be called
-        raise RuntimeError("stub")
-
-
-class _StubAerSimulator:
-    def __init__(self, **_):
-        pass
-
-    def run(self, *_args, **_kwargs):
-        return _StubJob()
-
-
-setattr(_qiskit_aer_stub, "AerSimulator", _StubAerSimulator)
-_ensure_stub("qiskit_aer", _qiskit_aer_stub)
+    setattr(_qiskit_aer_stub, "AerSimulator", _StubAerSimulator)
+    _ensure_stub("qiskit_aer", _qiskit_aer_stub)
 
 
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -85,6 +90,12 @@ def _fake_analyze() -> mock.Mock:
 @pytest.fixture(autouse=True)
 def patch_analyze(monkeypatch):
     monkeypatch.setattr(runner, "analyze", lambda circuit: _fake_analyze())
+
+
+def _require_fork_start_method() -> None:
+    method = multiprocessing.get_start_method(allow_none=True)
+    if method == "spawn":  # pragma: no cover - platform dependent
+        pytest.skip("timeout tests require fork start method")
 
 
 def test_statevector_backend_propagates_timeout(monkeypatch):
@@ -138,11 +149,10 @@ def test_decision_diagram_backend_propagates_timeout(monkeypatch):
 
 
 def test_run_backend_reports_timeout_estimate(monkeypatch):
-    class _TimeoutBackend(runner.StatevectorBackend):
-        def run(self, circuit):  # type: ignore[override]
-            raise TimeoutError("boom")
+    def _raise_timeout(*args, **kwargs):
+        raise TimeoutError("boom")
 
-    monkeypatch.setattr(runner, "StatevectorBackend", _TimeoutBackend)
+    monkeypatch.setattr(runner, "_run_backend_subprocess", _raise_timeout)
 
     result = runner._run_backend("sv", _FakeCircuit(), timeout_s=1.0, sv_ampops_per_sec=123.0)
 
@@ -167,3 +177,47 @@ def test_run_backend_reports_memory_estimate(monkeypatch):
     assert "estimate" in result
     assert result.get("wall_s_estimated") == result["estimate"].get("time_est_sec")
     assert result.get("mem_bytes_estimated") == result["estimate"].get("mem_bytes")
+
+
+def test_run_backend_timeout_uses_subprocess(monkeypatch):
+    _require_fork_start_method()
+
+    def _slow_impl(which, circuit, *, max_ram_gb=None, sv_ampops_per_sec=None, timeout_s=None):
+        time.sleep(0.3)
+        return {
+            "ok": True,
+            "backend": which,
+            "elapsed_s": 0.3,
+            "wall_s_measured": 0.3,
+        }
+
+    monkeypatch.setattr(runner, "_run_backend_impl", _slow_impl)
+    monkeypatch.setattr(runner, "_estimate_sv", lambda circuit, ampops_per_sec=None: {"mem_bytes": 0})
+
+    result = runner._run_backend("sv", _FakeCircuit(), timeout_s=0.1, sv_ampops_per_sec=None)
+
+    assert result["backend"] == "sv"
+    assert result["ok"] is False
+    assert result["error"].startswith("Timeout")
+
+
+def test_run_backend_timeout_dd_subprocess(monkeypatch):
+    _require_fork_start_method()
+
+    def _slow_impl(which, circuit, *, max_ram_gb=None, sv_ampops_per_sec=None, timeout_s=None):
+        time.sleep(0.3)
+        return {
+            "ok": True,
+            "backend": which,
+            "elapsed_s": 0.3,
+            "wall_s_measured": 0.3,
+        }
+
+    monkeypatch.setattr(runner, "_run_backend_impl", _slow_impl)
+    monkeypatch.setattr(runner, "_estimate_sv", lambda circuit, ampops_per_sec=None: {"mem_bytes": 0})
+
+    result = runner._run_backend("dd", _FakeCircuit(), timeout_s=0.1, sv_ampops_per_sec=None)
+
+    assert result["backend"] == "dd"
+    assert result["ok"] is False
+    assert result["error"].startswith("Timeout")


### PR DESCRIPTION
## Summary
- run baselines that specify a timeout inside dedicated subprocesses so they can be terminated cleanly
- keep decision-diagram support working under the new execution model and reuse the same error handling paths
- add regression tests that exercise the timeout paths and prefer real numpy/qiskit modules when they are installed

## Testing
- pytest tests/test_baselines_runner.py tests/test_bench_from_thresholds.py

------
https://chatgpt.com/codex/tasks/task_e_68e538a762e88321b6db356100222c13