### PR TITLE
Add baseline selector for disjoint suite

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -168,6 +168,8 @@ Key options:
   through to `suites/run_disjoint_suite.py`.
 - `--parallel-workers` controls how many worker processes QuASAr should use
   when executing disjoint blocks in parallel (defaults to an automatic choice).
+- `--baseline` limits the baseline comparison to a single backend. Accepts
+  `tableau`/`tab`, `sv`, or `dd` and is forwarded to the suite runner.
 
 #### Consolidated tables
 

--- a/scripts/make_figures_and_tables.py
+++ b/scripts/make_figures_and_tables.py
@@ -308,6 +308,11 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
         runner_args.extend(["--parallel-workers", str(args.parallel_workers)])
     if args.seed is not None:
         runner_args.extend(["--seed", str(args.seed)])
+    if args.baseline is not None:
+        baseline = args.baseline.lower()
+        if baseline == "tab":
+            baseline = "tableau"
+        runner_args.extend(["--baseline", baseline])
 
     _ensure_suite(
         "run_disjoint_suite.py",
@@ -557,6 +562,13 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Override the number of parallel workers when executing disjoint blocks",
+    )
+    disjoint.add_argument(
+        "--baseline",
+        type=str,
+        choices=["tableau", "tab", "sv", "dd"],
+        default=None,
+        help="Restrict baselines to a single backend (tableau/tab, sv, or dd)",
     )
     disjoint.set_defaults(func=cmd_disjoint)
 

--- a/suites/run_disjoint_suite.py
+++ b/suites/run_disjoint_suite.py
@@ -124,9 +124,17 @@ def run_case(
 
     if circ is not None:
         try:
+            if args.baseline is None:
+                which = ["tableau", "sv", "dd"]
+            else:
+                baseline = args.baseline
+                if baseline == "tab":
+                    baseline = "tableau"
+                which = [baseline]
+
             baselines = run_baselines(
                 circ,
-                which=["tableau", "sv", "dd"],
+                which=which,
                 per_partition=False,
                 max_ram_gb=float(args.max_ram_gb),
                 sv_ampops_per_sec=args.sv_ampops_per_sec,
@@ -170,6 +178,13 @@ def parse_args() -> argparse.Namespace:
         help="Number of parallel workers to use for executing disjoint blocks (0 = auto)",
     )
     parser.add_argument("--seed", type=int, default=None, help="Optional RNG seed for circuit construction")
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        default=None,
+        choices=["tableau", "sv", "dd", "tab"],
+        help="Restrict baselines to a single backend (tableau/tab, sv, or dd)",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Summary
- add a --baseline flag to the disjoint make_figures helper that forwards to the suite runner
- allow run_disjoint_suite to restrict baselines to a single backend (tableau/tab, sv, or dd)
- document the new option in the workflow README

## Testing
- python -m compileall scripts/make_figures_and_tables.py suites/run_disjoint_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68e53a6c387c83218bfabd6e5af86a44