### PR TITLE
Annotate memory savings on QuASAr bar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -198,13 +198,15 @@ All plotters now live under `plots/`:
   two-bar chart per `(n, blocks)` pair showing QuASAr's parallel runtime next to
   the best whole-circuit baseline with the simulator type encoded in the bar
   colour. Pass `--memory-out` (or `--memory-out=auto` alongside `--out`) to also
-  render the memory comparison plot in a single invocation.
+  render the memory comparison plot in a single invocation, and `--log` to draw
+  the memory bars on a logarithmic scale when differences become extreme.
 - `plots/compare_total.py` — convenience helpers to compare total QuASAr vs
   baseline runtimes or visualise SSD partition timings.
 
 Each plotter accepts `--suite-dir` (directory with suite JSON files) and `--out`
 for the output image path; `bar_disjoint` additionally exposes `--memory-out`
-to render the memory comparison bars.
+to render the memory comparison bars and `--log` to switch those bars to a
+logarithmic scale.
 
 ## Ablation study script
 


### PR DESCRIPTION
## Summary
- highlight the memory savings factor directly above the QuASAr bar in the disjoint memory plot
- ensure annotations behave for both linear and logarithmic memory scales

## Testing
- python -m compileall plots/bar_disjoint.py

------
https://chatgpt.com/codex/tasks/task_e_68e53f6cb5bc83218e55bfe4f2bb672f