### PR TITLE
Prefer estimated baseline runtimes on failure

### DIFF
--- a/plots/bar_clifford_tail.py
+++ b/plots/bar_clifford_tail.py
@@ -73,12 +73,27 @@ def _flatten_baseline_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _pick_elapsed(payload: Dict[str, Any]) -> Optional[float]:
-    for key in ("wall_s_measured", "wall_s_estimated", "elapsed_s", "time_est_sec"):
-        if key in payload and payload[key] is not None:
-            try:
-                return float(payload[key])
-            except Exception:
-                continue
+    if not isinstance(payload, dict):
+        return None
+
+    prefer_estimated = False
+    if payload.get("ok") is False:
+        prefer_estimated = True
+    elif payload.get("error") and payload.get("wall_s_estimated") is not None:
+        prefer_estimated = True
+
+    if prefer_estimated:
+        order = ["wall_s_estimated", "time_est_sec", "wall_s_measured", "elapsed_s"]
+    else:
+        order = ["wall_s_measured", "elapsed_s", "wall_s_estimated", "time_est_sec"]
+
+    for key in order:
+        if key not in payload or payload[key] is None:
+            continue
+        try:
+            return float(payload[key])
+        except Exception:
+            continue
     return None
 
 

--- a/plots/bar_disjoint.py
+++ b/plots/bar_disjoint.py
@@ -105,12 +105,28 @@ def _extract_quasar_time(data: Dict[str, Any]) -> Optional[float]:
 
 
 def _pick_elapsed(payload: Dict[str, Any]) -> Optional[float]:
-    for key in ("wall_s_measured", "wall_s_estimated", "elapsed_s", "time_est_sec"):
-        if key in payload and payload[key] is not None:
-            try:
-                return float(payload[key])
-            except Exception:
-                continue
+    if not isinstance(payload, dict):
+        return None
+
+    prefer_estimated = False
+    if payload.get("ok") is False:
+        prefer_estimated = True
+    elif payload.get("error") and payload.get("wall_s_estimated") is not None:
+        prefer_estimated = True
+
+    key_orders: List[str]
+    if prefer_estimated:
+        key_orders = ["wall_s_estimated", "time_est_sec", "wall_s_measured", "elapsed_s"]
+    else:
+        key_orders = ["wall_s_measured", "elapsed_s", "wall_s_estimated", "time_est_sec"]
+
+    for key in key_orders:
+        if key not in payload or payload[key] is None:
+            continue
+        try:
+            return float(payload[key])
+        except Exception:
+            continue
     return None
 
 

--- a/plots/plan_breakdown.py
+++ b/plots/plan_breakdown.py
@@ -48,7 +48,21 @@ COMPONENT_COLORS = {
 
 
 def _pick_elapsed(payload: Dict[str, Any]) -> Optional[float]:
-    for key in ("elapsed_s", "wall_s_measured", "wall_s_estimated"):
+    if not isinstance(payload, dict):
+        return None
+
+    prefer_estimated = False
+    if payload.get("ok") is False:
+        prefer_estimated = True
+    elif payload.get("error") and payload.get("wall_s_estimated") is not None:
+        prefer_estimated = True
+
+    if prefer_estimated:
+        order = ["wall_s_estimated", "time_est_sec", "wall_s_measured", "elapsed_s"]
+    else:
+        order = ["elapsed_s", "wall_s_measured", "wall_s_estimated", "time_est_sec"]
+
+    for key in order:
         value = payload.get(key)
         if value is None:
             continue


### PR DESCRIPTION
## Summary
- ensure the plotting helpers prefer estimated baseline runtimes when a backend fails
- update disjoint, Clifford-tail, and plan breakdown visualizers to fall back to estimates on memory errors

## Testing
- python -m compileall plots

------
https://chatgpt.com/codex/tasks/task_e_68e5fac41ab0832196ed55d4eb9db2d3