### PR TITLE
Handle Aer 'COMPLETED' status for statevector runs

### DIFF
--- a/quasar/backends/sv.py
+++ b/quasar/backends/sv.py
@@ -67,7 +67,7 @@ class StatevectorBackend:
     @staticmethod
     def _collect_result_errors(result: Any) -> Iterable[str]:
         status = getattr(result, "status", None)
-        if isinstance(status, str) and status and status.lower() not in {"success", "done"}:
+        if isinstance(status, str) and status and status.lower() not in {"success", "done", "completed"}:
             yield status.strip()
         experiments = getattr(result, "results", None)
         if isinstance(experiments, Iterable):


### PR DESCRIPTION
## Summary
- treat Aer simulator "COMPLETED" status as a successful run for statevector baselines

## Testing
- python -m suites.run_disjoint_suite --n 4 --blocks 1 --tail-depth 4 --min-tail-depth 4 --out-dir tmp_suite2 --max-ram-gb 2 --sv-ampops-per-sec 1

------
https://chatgpt.com/codex/tasks/task_e_68e5fbe8fc2083219719265bce290e98