### PR TITLE
Add backend-aligned disjoint circuit variant flag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,9 @@ Circuit generators live under `benchmarks/`:
 tails optimised for decision-diagram simulators.
 - `benchmarks.disjoint` — block-disjoint preparation + tail families with
   configurable GHZ/W prep and Clifford/diagonal/random tails. Blocks are constructed
-  without cross-couplings so they can be simulated in parallel.
+  without cross-couplings so they can be simulated in parallel. A backend-aligned
+  builder is also available to dedicate even/odd blocks to tableau and decision-diagram
+  partitions respectively.
 - `benchmarks.__init__` — registry aggregator. Import
   `from benchmarks import build` to fetch any circuit by name.
 
@@ -176,6 +178,9 @@ Key options:
   through to `suites/run_disjoint_suite.py`.
 - `--parallel-workers` controls how many worker processes QuASAr should use
   when executing disjoint blocks in parallel (defaults to an automatic choice).
+- `--backend-var` switches to the backend-aligned circuit generator so even-indexed
+  blocks stay Clifford-only for the tableau backend while odd-indexed blocks keep
+  diagonal tails for the decision-diagram backend.
 - `--baseline` limits the baseline comparison to a single backend. Accepts
   `tableau`/`tab`, `sv`, or `dd` and is forwarded to the suite runner.
 

--- a/scripts/make_figures_and_tables.py
+++ b/scripts/make_figures_and_tables.py
@@ -365,6 +365,8 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
         if baseline == "tab":
             baseline = "tableau"
         runner_args.extend(["--baseline", baseline])
+    if args.backend_var:
+        runner_args.append("--backend-var")
 
     _ensure_suite(
         "run_disjoint_suite.py",
@@ -623,6 +625,15 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Override the number of parallel workers when executing disjoint blocks",
+    )
+    disjoint.add_argument(
+        "--backend-var",
+        action="store_true",
+        help=(
+            "Switch to the backend-aligned circuit generator so even-indexed blocks"
+            " target the tableau backend and odd-indexed blocks target the decision"
+            " diagram backend"
+        ),
     )
     disjoint.add_argument(
         "--baseline",

--- a/scripts/make_figures_and_tables.py
+++ b/scripts/make_figures_and_tables.py
@@ -318,6 +318,8 @@ def cmd_hybrid(args: argparse.Namespace) -> None:
 
 def cmd_disjoint(args: argparse.Namespace) -> None:
     from plots.bar_disjoint import (
+        BACKEND_ALIGNED_CASE_KIND,
+        DEFAULT_CASE_KIND,
         make_memory_plot as make_disjoint_memory_bars,
         make_plot as make_disjoint_bars,
     )
@@ -368,6 +370,11 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
     if args.backend_var:
         runner_args.append("--backend-var")
 
+    if args.backend_var:
+        case_kinds = (BACKEND_ALIGNED_CASE_KIND,)
+    else:
+        case_kinds = (DEFAULT_CASE_KIND,)
+
     _ensure_suite(
         "run_disjoint_suite.py",
         suite_dir=suite_dir,
@@ -381,7 +388,12 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
         return
 
     print(f"[make_figures] Building disjoint bar chart -> {out_path}")
-    make_disjoint_bars(str(suite_dir), out=str(out_path), title=args.title)
+    make_disjoint_bars(
+        str(suite_dir),
+        out=str(out_path),
+        title=args.title,
+        case_kinds=case_kinds,
+    )
 
     if out_path.suffix:
         memory_out = out_path.with_name(f"{out_path.stem}_memory{out_path.suffix}")
@@ -389,7 +401,12 @@ def cmd_disjoint(args: argparse.Namespace) -> None:
         memory_out = out_path.with_name(f"{out_path.name}_memory")
 
     print(f"[make_figures] Building disjoint memory chart -> {memory_out}")
-    make_disjoint_memory_bars(str(suite_dir), out=str(memory_out), title=args.title)
+    make_disjoint_memory_bars(
+        str(suite_dir),
+        out=str(memory_out),
+        title=args.title,
+        case_kinds=case_kinds,
+    )
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add a backend-aligned disjoint circuit generator and expose it behind the new `--backend-var` flag in the suite runner and figure pipeline
- document the backend-aligned option while restoring the statevector backend to the dedicated Aer statevector method

## Testing
- python -m compileall benchmarks/disjoint.py suites/run_disjoint_suite.py scripts/make_figures_and_tables.py

------
https://chatgpt.com/codex/tasks/task_e_68e6026d2bb48321ba5414a3d0c17eef