### PR TITLE
Streamline ablation study workflow with hybrid block circuit builder

### DIFF
--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -79,8 +79,6 @@ def _build_subcircuit_like(parent, ops: List):
 def _consider_hybrid(node: PartitionNode, cfg: PlannerConfig):
     if not cfg.hybrid_clifford_tail:
         return None
-    if int(node.id) % 2 == 1:
-        return None
     split = _split_at_first_nonclifford(node)
     if not split:
         return None


### PR DESCRIPTION
## Summary
- replace the ablation study helper with a compact circuit builder that emits disjoint hybrid blocks and drives the three planner variants
- surface per-block metadata, collapsed planning fallback, and JSON summaries for lightweight experimentation
- ensure the planner always considers hybrid splitting and add a regression test covering random vs sparse hybrid tails

## Testing
- pytest tests/test_run_ablation_study.py
- python -m scripts.run_ablation_study --num-components 2 --component-size 2 --clifford-depth 1 --tail-depth 1 --seed 3

------
https://chatgpt.com/codex/tasks/task_e_68e61289943883219adf04231a560cda