### PR TITLE
Improve ablation study reporting and backend support

### DIFF
--- a/plots/plot_ablation_bars.py
+++ b/plots/plot_ablation_bars.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 
@@ -30,11 +30,32 @@ class VariantMetrics:
 
     name: str
     wall_time_s: float
-    max_mem_gb: float
+    max_mem_bytes: int
+    wall_time_estimated: bool = False
+    max_mem_estimated: bool = False
+
+    @property
+    def max_mem_gib(self) -> float:
+        return self.max_mem_bytes / float(1024**3)
 
 
 def _as_variant_metrics(record: Dict[str, object]) -> VariantMetrics:
     name = str(record.get("name", "unknown"))
+
+    summary = record.get("summary")
+    if isinstance(summary, dict):
+        wall = float(summary.get("wall_time_s", 0.0))
+        max_mem = int(summary.get("max_mem_bytes", 0))
+        wall_est = bool(summary.get("wall_time_estimated", False))
+        mem_est = bool(summary.get("max_mem_estimated", False))
+        return VariantMetrics(
+            name=name,
+            wall_time_s=wall,
+            max_mem_bytes=max_mem,
+            wall_time_estimated=wall_est,
+            max_mem_estimated=mem_est,
+        )
+
     execution = record.get("execution")
     if not isinstance(execution, dict):
         raise ValueError(f"Variant '{name}' is missing execution data")
@@ -47,11 +68,47 @@ def _as_variant_metrics(record: Dict[str, object]) -> VariantMetrics:
         raise ValueError(f"Variant '{name}' has no execution results to summarise")
 
     max_mem_bytes = 0
+    mem_estimated = False
     for entry in results:
         if isinstance(entry, dict):
-            max_mem_bytes = max(max_mem_bytes, int(entry.get("mem_bytes", 0)))
+            mem = entry.get("mem_bytes")
+            estimated = False
+            if mem is None:
+                mem = entry.get("mem_bytes_estimated")
+                if mem is not None:
+                    estimated = True
+            if mem is None:
+                continue
+            mem_int = int(mem)
+            if mem_int > max_mem_bytes:
+                max_mem_bytes = mem_int
+                mem_estimated = estimated
 
-    return VariantMetrics(name=name, wall_time_s=wall, max_mem_gb=max_mem_bytes / (1024**3))
+    return VariantMetrics(
+        name=name,
+        wall_time_s=wall,
+        max_mem_bytes=max_mem_bytes,
+        max_mem_estimated=mem_estimated,
+    )
+
+
+def _memory_values(metrics: List[VariantMetrics]) -> Tuple[List[float], str]:
+    if not metrics:
+        return [], "GiB"
+    max_bytes = max(m.max_mem_bytes for m in metrics)
+    if max_bytes <= 0:
+        return [0.0 for _ in metrics], "GiB"
+    if max_bytes >= 1024**3:
+        divisor = float(1024**3)
+        unit = "GiB"
+    elif max_bytes >= 1024**2:
+        divisor = float(1024**2)
+        unit = "MiB"
+    else:
+        divisor = 1024.0
+        unit = "KiB"
+    values = [m.max_mem_bytes / divisor for m in metrics]
+    return values, unit
 
 
 def collect_variant_metrics(summary: Dict[str, object]) -> List[VariantMetrics]:
@@ -85,14 +142,14 @@ def plot_metrics(metrics: List[VariantMetrics], *, output: Optional[Path] = None
 
     labels = [m.name for m in metrics]
     runtimes = [m.wall_time_s for m in metrics]
-    memories = [m.max_mem_gb for m in metrics]
+    memories, mem_unit = _memory_values(metrics)
 
     fig, (ax_runtime, ax_memory) = plt.subplots(1, 2, figsize=(10, 4))
     if title:
         fig.suptitle(title)
 
     _plot_bars(ax_runtime, labels, runtimes, title="Runtime", ylabel="Seconds")
-    _plot_bars(ax_memory, labels, memories, title="Memory", ylabel="GiB")
+    _plot_bars(ax_memory, labels, memories, title="Memory", ylabel=mem_unit)
 
     fig.tight_layout(rect=(0, 0, 1, 0.95) if title else None)
 

--- a/quasar/backends/sv.py
+++ b/quasar/backends/sv.py
@@ -51,6 +51,9 @@ def _apply_operation(circuit: QuantumCircuit, op: Operation) -> None:
     if name == "cp":
         circuit.cp(params[0] if params else 0.0, qubits[0], qubits[1])
         return
+    if name == "crx":
+        circuit.crx(params[0] if params else 0.0, qubits[0], qubits[1])
+        return
     if name == "rzz":
         circuit.rzz(params[0] if params else 0.0, qubits[0], qubits[1])
         return

--- a/tests/test_run_ablation_study.py
+++ b/tests/test_run_ablation_study.py
@@ -60,21 +60,20 @@ def test_collect_variant_metrics_extracts_wall_and_memory() -> None:
         "variants": [
             {
                 "name": "full",
-                "execution": {
-                    "meta": {"wall_elapsed_s": 3.2},
-                    "results": [
-                        {"mem_bytes": 512 * 1024**2},
-                        {"mem_bytes": 2 * 1024**3},
-                    ],
+                "summary": {
+                    "wall_time_s": 3.2,
+                    "max_mem_bytes": 2 * 1024**3,
+                    "wall_time_estimated": False,
+                    "max_mem_estimated": False,
                 },
             },
             {
                 "name": "no_disjoint",
-                "execution": {
-                    "meta": {"wall_elapsed_s": 4.8},
-                    "results": [
-                        {"mem_bytes": 3 * 1024**3},
-                    ],
+                "summary": {
+                    "wall_time_s": 4.8,
+                    "max_mem_bytes": 3 * 1024**3,
+                    "wall_time_estimated": True,
+                    "max_mem_estimated": True,
                 },
             },
         ]
@@ -83,5 +82,7 @@ def test_collect_variant_metrics_extracts_wall_and_memory() -> None:
     metrics = pab.collect_variant_metrics(summary)
     assert [m.name for m in metrics] == ["full", "no_disjoint"]
     assert metrics[0].wall_time_s == pytest.approx(3.2)
-    assert metrics[0].max_mem_gb == pytest.approx(2.0)
-    assert metrics[1].max_mem_gb == pytest.approx(3.0)
+    assert metrics[0].max_mem_bytes == 2 * 1024**3
+    assert metrics[0].max_mem_gib == pytest.approx(2.0)
+    assert metrics[1].max_mem_gib == pytest.approx(3.0)
+    assert metrics[1].wall_time_estimated is True


### PR DESCRIPTION
## Summary
- enrich the ablation study runner with execution summaries that track measured and modeled runtimes, memory estimates, and calibrated throughput for variants
- adjust the plotting helpers to consume the new summary data and scale memory bars using appropriate units while preserving estimate flags
- teach the statevector backend to handle CRX gates to avoid execution failures on random rotation tails

## Testing
- PYTHONPATH=. pytest tests/test_run_ablation_study.py


------
https://chatgpt.com/codex/tasks/task_e_68e623ae43608321ad22e40504aca378