### PR TITLE
Fix simulation backend concurrency hangs

### DIFF
--- a/quasar/simulation_engine.py
+++ b/quasar/simulation_engine.py
@@ -152,7 +152,11 @@ def execute_ssd(ssd: SSD, cfg: Optional[ExecutionConfig] = None) -> Dict[str, An
 
     chains = _group_chains(ssd)
     if cfg.max_workers <= 0:
-        desired = max(1, len(chains))
+        sensitive_backends = {"sv", "dd"}
+        has_sensitive = any(
+            str((node.backend or "sv")).lower() in sensitive_backends for node in ssd.partitions
+        )
+        desired = 1 if has_sensitive else max(1, len(chains))
         if cpu_count is None:
             cfg.max_workers = desired
         else:


### PR DESCRIPTION
## Summary
- guard the DDSIM and Aer statevector backends with module-level locks so they can run safely under threading
- adjust the simulation engine to serialize execution when sensitive backends are present
- update the simulation-engine tests to cover the new worker-selection behavior

## Testing
- pytest tests/test_simulation_engine.py
- python -m scripts.run_ablation_study --num-components 4 --component-size 2 --clifford-depth 80 --tail-depth 20 --seed 11 --out summary.json --execute


------
https://chatgpt.com/codex/tasks/task_e_68e63567abc883219a5e2979f6344dd9