### PR TITLE
Expose max worker override in ablation CLI

### DIFF
--- a/scripts/run_ablation_study.py
+++ b/scripts/run_ablation_study.py
@@ -622,6 +622,15 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     )
     parser.add_argument("--seed", type=int, default=1, help="Random seed for the circuit constructor")
     parser.add_argument("--execute", action="store_true", help="Execute the planned SSDs via the simulation engine")
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help=(
+            "Maximum number of execution workers. Defaults to the executor's"
+            " backend-aware heuristic when omitted."
+        ),
+    )
     parser.add_argument("--out", type=str, default=None, help="Optional path to store the JSON summary")
     args = parser.parse_args(argv)
 
@@ -634,7 +643,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         seed=args.seed,
     )
 
-    summary = run_three_way_ablation(circuit, execute=args.execute)
+    exec_cfg = ExecutionConfig()
+    if args.max_workers is not None:
+        exec_cfg.max_workers = args.max_workers
+
+    summary = run_three_way_ablation(circuit, execute=args.execute, exec_cfg=exec_cfg)
 
     if args.out:
         out_path = Path(args.out).resolve()


### PR DESCRIPTION
## Summary
- add a `--max-workers` option to the ablation CLI and forward it through `ExecutionConfig`
- document the new knob and fix the execution-config example in the ablation study guide

## Testing
- pytest tests/test_run_ablation_study.py::test_streamlined_hybrid_blocks_split

------
https://chatgpt.com/codex/tasks/task_e_68e64ef6ceb48321a7ba39177994dc7d