### PR TITLE
Scope forced statevector to collapsed ablation variant

### DIFF
--- a/scripts/run_ablation_study.py
+++ b/scripts/run_ablation_study.py
@@ -195,7 +195,11 @@ def _collapse_to_single_partition(ssd: SSD, circuit: QuantumCircuit) -> SSD:
             qubits=list(range(circuit.num_qubits)),
             circuit=stitched,
             metrics=metrics,
-            meta={"collapsed": True},
+            meta={
+                "collapsed": True,
+                "forced_backend": "sv",
+                "forced_backend_reason": "forced_single_partition",
+            },
         )
     )
     return merged


### PR DESCRIPTION
## Summary
- mark the ablation study's collapsed variant with explicit forced-backend metadata
- honor forced backend metadata in the planner while leaving other collapsed plans to auto-select

## Testing
- pytest tests/test_run_ablation_study.py -k no_disjoint

------
https://chatgpt.com/codex/tasks/task_e_68e6699fd7388321830b075a4ed335e5